### PR TITLE
Bugfix/domain tree fix

### DIFF
--- a/pkg/domain/asset_tree.go
+++ b/pkg/domain/asset_tree.go
@@ -4,7 +4,7 @@ type AssetTree struct {
 	AssetTreeMeta struct {
 		Size    int  `json:"size"`
 		Partial bool `json:"partial"`
-			} `json:"assetTreeMeta"`
+	} `json:"assetTreeMeta"`
 	AssetTree []struct {
 		TargetRef     string        `json:"targetRef"`
 		Hidden        bool          `json:"hidden"`
@@ -12,7 +12,7 @@ type AssetTree struct {
 		Icon          string        `json:"icon"`
 		Type          string        `json:"type"`
 		URL           string        `json:"url"`
-		ParentID      string        `json:"parentId"`
+		ParentID      int           `json:"parentId"`
 		Path          string        `json:"path"`
 		Ref           string        `json:"ref"`
 		Depth         int           `json:"depth"`


### PR DESCRIPTION
asset_tree parentId was a string and needed to be changed to an int.

![image](https://user-images.githubusercontent.com/72458129/160676119-e508647f-3cc5-4114-8316-f5e0ea96239a.png)
