### PR TITLE
feature/TSP-2439_DeleteTag

### DIFF
--- a/pkg/domain/ref_test.go
+++ b/pkg/domain/ref_test.go
@@ -17,6 +17,9 @@ func TestRef_GetPrefix(t *testing.T) {
 
 	abc := Ref{Value: "abc.xxxxxxxx-xxxxxxxx"}
 	assert.Equal(t, "abc", abc.GetPrefix())
+
+	noPrefix := Ref{Value: "xxxxxxxx-xxxxxxxx"}
+	assert.Equal(t, "", noPrefix.GetPrefix())
 }
 
 func TestRef_String(t *testing.T) {

--- a/pkg/starkapi/assets_api.go
+++ b/pkg/starkapi/assets_api.go
@@ -12,20 +12,12 @@ type AssetsApi struct {
 	client *Client
 }
 
-func assetsUrl(host string) string {
-	return fmt.Sprintf("%s/core/assets", host)
-}
-
-func assetUrl(host string, ref uint32) string {
-	return fmt.Sprintf("%s/%d", assetsUrl(host), ref)
-}
-
 func (assetsApi *AssetsApi) host() string {
 	return assetsApi.client.host
 }
 
 func (assetsApi *AssetsApi) BaseUrl() string {
-	return fmt.Sprintf("%s/core/assets", assetsApi.client.host)
+	return fmt.Sprintf("%s/core/assets", assetsApi.host())
 }
 
 func (assetsApi *AssetsApi) AddNewTag(asset domain.Asset, name string, value string) error {

--- a/pkg/starkapi/assets_api.go
+++ b/pkg/starkapi/assets_api.go
@@ -54,3 +54,7 @@ func (assetsApi *AssetsApi) AddNewTag(asset domain.Asset, name string, value str
 
 	return nil
 }
+
+func (assetsApi *AssetsApi) DeleteTag(asset domain.Asset, name string, value string) error {
+	return nil
+}

--- a/pkg/starkapi/assets_api.go
+++ b/pkg/starkapi/assets_api.go
@@ -55,6 +55,23 @@ func (assetsApi *AssetsApi) AddNewTag(asset domain.Asset, name string, value str
 	return nil
 }
 
-func (assetsApi *AssetsApi) DeleteTag(asset domain.Asset, name string, value string) error {
+func (assetsApi *AssetsApi) DeleteTag(asset domain.Asset, name string) error {
+	if len(name) < 1 {
+		logger.Error("invalid tag name in assets/DeleteTag.")
+		return errors.New("invalid tag name")
+	}
+
+	if len(asset.Ref) < 1 {
+		logger.Error("invalid asset in assets/DeleteTag. Asset does not have a ref.")
+		return errors.New("invalid asset")
+	}
+
+	url := fmt.Sprintf("%s/%v/tags", assetsApi.BaseUrl(), asset.Ref)
+
+	_, err := assetsApi.client.delete(url)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/starkapi/assets_api_test.go
+++ b/pkg/starkapi/assets_api_test.go
@@ -11,7 +11,10 @@ import (
 func TestAddTagToAsset(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path !=  "/core/assets/e.test/tags" {
-			t.Errorf("Expected to request '%s', got: %s", "/tags" , r.URL.Path)
+			t.Errorf("Expected to request '%s', got: %s", "/core/assets/e.test/tags" , r.URL.Path)
+		}
+		if r.Method !=  http.MethodPost {
+			t.Errorf("Expected a %s request , got: %s",http.MethodPost, r.Method)
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -51,5 +54,54 @@ func TestAddTagToAsset(t *testing.T) {
 	}
 
 	badAssetErr := assetsApi.AddNewTag(badAsset, "Test", "1")
+	assert.NotEqual(t, nil, badAssetErr)
+}
+
+func TestDeleteTagFromAsset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path !=  "/core/assets/e.test/tags" {
+			t.Errorf("Expected to request '%s', got: %s", "/core/assets/e.test/tags" , r.URL.Path)
+		}
+		if r.Method !=  http.MethodDelete {
+			t.Errorf("Expected a %s request , got: %s",http.MethodDelete, r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	api := Client{}
+	host := server.URL
+
+	api.Init(host)
+
+	//Test valid asset
+	asset := domain.Asset{
+		Id:   1,
+		Ref:  "e.test",
+		Url:  "test/url",
+		Name: "Test",
+		Type: "Equip",
+	}
+
+	assetsApi := api.AssetsApi
+
+	assetErr := assetsApi.DeleteTag(asset, "Test")
+	assert.Equal(t, nil, assetErr)
+
+
+	//Test invalid tag
+	badTagErr := assetsApi.DeleteTag(asset, "")
+	assert.NotEqual(t, nil, badTagErr)
+
+	//Test asset with no Ref
+	badAsset := domain.Asset{
+		Id:   1,
+		Ref:  "",
+		Url:  "test/url",
+		Name: "",
+		Type: "Equip",
+	}
+
+	badAssetErr := assetsApi.DeleteTag(badAsset, "Test")
 	assert.NotEqual(t, nil, badAssetErr)
 }

--- a/pkg/starkapi/assets_api_test.go
+++ b/pkg/starkapi/assets_api_test.go
@@ -78,7 +78,6 @@ func TestDeleteTagFromAsset(t *testing.T) {
 	asset := domain.Asset{
 		Id:   1,
 		Ref:  "e.test",
-		Url:  "test/url",
 		Name: "Test",
 		Type: "Equip",
 	}
@@ -97,7 +96,6 @@ func TestDeleteTagFromAsset(t *testing.T) {
 	badAsset := domain.Asset{
 		Id:   1,
 		Ref:  "",
-		Url:  "test/url",
 		Name: "",
 		Type: "Equip",
 	}

--- a/pkg/starkapi/assets_api_test.go
+++ b/pkg/starkapi/assets_api_test.go
@@ -8,7 +8,16 @@ import (
 	"testing"
 )
 
+const testHost =  "https://test.com"
 const testURLWithRef =  "/core/assets/e.test/tags"
+
+func TestAssetsApi_HostUrl(t *testing.T) {
+	api := Client{}
+	host := testHost
+	api.Init(host)
+	assetsApi := api.AssetsApi
+	assert.Equal(t, testHost, assetsApi.host())
+}
 
 func TestAddTagToAsset(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/starkapi/assets_api_test.go
+++ b/pkg/starkapi/assets_api_test.go
@@ -31,7 +31,6 @@ func TestAddTagToAsset(t *testing.T) {
 	asset := domain.Asset{
 		Id:   1,
 		Ref:  "e.test",
-		Url:  "test/url",
 		Name: "Test",
 		Type: "Equip",
 	}
@@ -50,7 +49,6 @@ func TestAddTagToAsset(t *testing.T) {
 	badAsset := domain.Asset{
 		Id:   1,
 		Ref:  "",
-		Url:  "test/url",
 		Name: "",
 		Type: "Equip",
 	}

--- a/pkg/starkapi/assets_api_test.go
+++ b/pkg/starkapi/assets_api_test.go
@@ -8,10 +8,12 @@ import (
 	"testing"
 )
 
+const testURLWithRef =  "/core/assets/e.test/tags"
+
 func TestAddTagToAsset(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path !=  "/core/assets/e.test/tags" {
-			t.Errorf("Expected to request '%s', got: %s", "/core/assets/e.test/tags" , r.URL.Path)
+		if r.URL.Path !=  testURLWithRef {
+			t.Errorf("Expected to request '%s', got: %s", testURLWithRef , r.URL.Path)
 		}
 		if r.Method !=  http.MethodPost {
 			t.Errorf("Expected a %s request , got: %s",http.MethodPost, r.Method)
@@ -59,8 +61,8 @@ func TestAddTagToAsset(t *testing.T) {
 
 func TestDeleteTagFromAsset(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path !=  "/core/assets/e.test/tags" {
-			t.Errorf("Expected to request '%s', got: %s", "/core/assets/e.test/tags" , r.URL.Path)
+		if r.URL.Path !=  testURLWithRef {
+			t.Errorf("Expected to request '%s', got: %s", testURLWithRef , r.URL.Path)
 		}
 		if r.Method !=  http.MethodDelete {
 			t.Errorf("Expected a %s request , got: %s",http.MethodDelete, r.Method)


### PR DESCRIPTION
# Updates
- TSP-2439 As a Go SDK user, I can delete a tag from an asset

### Important Notes
- Added delete functionality and tests.
- Updated http mock tests to include MethodType checks.
