### PR TITLE
feature/TSP-2441_BulkAddTags

### DIFF
--- a/pkg/starkapi/assets_api.go
+++ b/pkg/starkapi/assets_api.go
@@ -58,6 +58,13 @@ func (assetsApi *AssetsApi) AddNewTags(asset domain.Asset, tags []domain.Tag) er
 		return errors.New("invalid asset")
 	}
 
+	for _, element := range tags {
+		if len(element.Name) < 1 {
+			logger.Error("invalid tag name in assets/AddNewTags.")
+			return errors.New("invalid tag name")
+		}
+	}
+
 	url := fmt.Sprintf("%s/%v/tags", assetsApi.BaseUrl(), asset.Ref)
 
 	body, err := json.Marshal(tags)

--- a/pkg/starkapi/assets_api.go
+++ b/pkg/starkapi/assets_api.go
@@ -47,6 +47,32 @@ func (assetsApi *AssetsApi) AddNewTag(asset domain.Asset, name string, value str
 	return nil
 }
 
+func (assetsApi *AssetsApi) AddNewTags(asset domain.Asset, tags []domain.Tag) error {
+	if len(tags) < 1 {
+		logger.Error("please provide at least one tag/AddNewTags.")
+		return errors.New("please provide at least one tag")
+	}
+
+	if len(asset.Ref) < 1 {
+		logger.Error("invalid asset in assets/AddNewTag. Asset does not have a ref.")
+		return errors.New("invalid asset")
+	}
+
+	url := fmt.Sprintf("%s/%v/tags", assetsApi.BaseUrl(), asset.Ref)
+
+	body, err := json.Marshal(tags)
+	if err != nil {
+		return err
+	}
+
+	_, err = assetsApi.client.post(url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (assetsApi *AssetsApi) DeleteTag(asset domain.Asset, name string) error {
 	if len(name) < 1 {
 		logger.Error("invalid tag name in assets/DeleteTag.")

--- a/pkg/starkapi/assets_api_test.go
+++ b/pkg/starkapi/assets_api_test.go
@@ -99,6 +99,10 @@ func TestAddTagsToAsset(t *testing.T) {
 	assetErr := assetsApi.AddNewTags(asset, tags)
 	assert.Equal(t, nil, assetErr)
 
+	//Test Tag with no name
+	tags = append(tags, domain.Tag{Name: "", Value: "1"})
+	noNameTagErr := assetsApi.AddNewTags(asset, tags)
+	assert.NotEqual(t, nil, noNameTagErr)
 
 	//Test empty tag array
 	var emptyTags []domain.Tag

--- a/pkg/starkapi/assets_api_test.go
+++ b/pkg/starkapi/assets_api_test.go
@@ -66,6 +66,57 @@ func TestAddTagToAsset(t *testing.T) {
 	assert.NotEqual(t, nil, badAssetErr)
 }
 
+func TestAddTagsToAsset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path !=  testURLWithRef {
+			t.Errorf("Expected to request '%s', got: %s", testURLWithRef , r.URL.Path)
+		}
+		if r.Method !=  http.MethodPost {
+			t.Errorf("Expected a %s request , got: %s",http.MethodPost, r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	api := Client{}
+	host := server.URL
+
+	api.Init(host)
+
+	//Test valid asset and tag array
+	asset := domain.Asset{
+		Id:   1,
+		Ref:  "e.test",
+		Name: "Test",
+		Type: "Equip",
+	}
+
+	var tags []domain.Tag
+	tags = append(tags, domain.Tag{Name: "Test", Value: "1"})
+
+	assetsApi := api.AssetsApi
+
+	assetErr := assetsApi.AddNewTags(asset, tags)
+	assert.Equal(t, nil, assetErr)
+
+
+	//Test empty tag array
+	var emptyTags []domain.Tag
+	badTagErr := assetsApi.AddNewTags(asset, emptyTags)
+	assert.NotEqual(t, nil, badTagErr)
+
+	//Test asset with no Ref
+	badAsset := domain.Asset{
+		Id:   1,
+		Ref:  "",
+		Name: "",
+		Type: "Equip",
+	}
+
+	badAssetErr := assetsApi.AddNewTag(badAsset, "Test", "1")
+	assert.NotEqual(t, nil, badAssetErr)
+}
+
 func TestDeleteTagFromAsset(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path !=  testURLWithRef {


### PR DESCRIPTION
# Updates
- TSP-2441 As a Go SDK user, I can bulk add tags to an asset

### Important Notes
- Added bulk add tags and tests.

