### PR TITLE
feature/TSP-2540_SDKTests

### DIFF
--- a/pkg/starkapi/asset_tree_api_test.go
+++ b/pkg/starkapi/asset_tree_api_test.go
@@ -1,0 +1,26 @@
+package starkapi
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const testAssetTreeApiAdminURL=  "/admin/branches"
+const testAssetTreeApiCoreURL =  "/core/branches"
+
+func TestAssetTreeApi_BaseUrl(t *testing.T) {
+	api := Client{}
+	host := testHost
+	api.Init(host)
+	assetTreeApi := api.AssetTreeApi
+	assert.Equal(t, fmt.Sprintf("%s%s", testHost, testAssetTreeApiCoreURL), assetTreeApi.baseUrl())
+}
+
+func TestAssetTreeApi_AdminUrl(t *testing.T) {
+	api := Client{}
+	host := testHost
+	api.Init(host)
+	assetTreeApi := api.AssetTreeApi
+	assert.Equal(t, fmt.Sprintf("%s%s", testHost, testAssetTreeApiAdminURL), assetTreeApi.adminUrl())
+}

--- a/pkg/starkapi/assets_api.go
+++ b/pkg/starkapi/assets_api.go
@@ -47,8 +47,8 @@ func (assetsApi *AssetsApi) AddNewTag(asset domain.Asset, name string, value str
 	return nil
 }
 
-func (assetsApi *AssetsApi) DeleteTag(asset domain.Asset, name string) error {
-	if len(name) < 1 {
+func (assetsApi *AssetsApi) DeleteTag(asset domain.Asset, tagName string) error {
+	if len(tagName) < 1 {
 		logger.Error("invalid tag name in assets/DeleteTag.")
 		return errors.New("invalid tag name")
 	}
@@ -58,7 +58,7 @@ func (assetsApi *AssetsApi) DeleteTag(asset domain.Asset, name string) error {
 		return errors.New("invalid asset")
 	}
 
-	url := fmt.Sprintf("%s/%v/tags", assetsApi.baseUrl(), asset.Ref)
+	url := fmt.Sprintf("%s/%v/tags/%s", assetsApi.baseUrl(), asset.Ref, tagName)
 
 	_, err := assetsApi.client.delete(url)
 	if err != nil {

--- a/pkg/starkapi/assets_api.go
+++ b/pkg/starkapi/assets_api.go
@@ -16,7 +16,7 @@ func (assetsApi *AssetsApi) host() string {
 	return assetsApi.client.host
 }
 
-func (assetsApi *AssetsApi) BaseUrl() string {
+func (assetsApi *AssetsApi) baseUrl() string {
 	return fmt.Sprintf("%s/core/assets", assetsApi.host())
 }
 
@@ -31,7 +31,7 @@ func (assetsApi *AssetsApi) AddNewTag(asset domain.Asset, name string, value str
 		return errors.New("invalid asset")
 	}
 
-	url := fmt.Sprintf("%s/%v/tags", assetsApi.BaseUrl(), asset.Ref)
+	url := fmt.Sprintf("%s/%v/tags", assetsApi.baseUrl(), asset.Ref)
 	ask := domain.Tag{Name: name, Value: value}
 
 	body, err := json.Marshal(ask)
@@ -58,7 +58,7 @@ func (assetsApi *AssetsApi) DeleteTag(asset domain.Asset, name string) error {
 		return errors.New("invalid asset")
 	}
 
-	url := fmt.Sprintf("%s/%v/tags", assetsApi.BaseUrl(), asset.Ref)
+	url := fmt.Sprintf("%s/%v/tags", assetsApi.baseUrl(), asset.Ref)
 
 	_, err := assetsApi.client.delete(url)
 	if err != nil {

--- a/pkg/starkapi/assets_api_test.go
+++ b/pkg/starkapi/assets_api_test.go
@@ -1,6 +1,7 @@
 package starkapi
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/Stark-Tech-Group/stg-sdk-golang/pkg/domain"
 	"github.com/stretchr/testify/assert"
@@ -30,12 +31,24 @@ func TestAssetsApi_BaseUrl(t *testing.T) {
 }
 
 func TestAddTagToAsset(t *testing.T) {
+	const badTagValue = "-1"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path !=  testAssetsApiURLWithRef {
-			t.Errorf("Expected to request '%s', got: %s", testAssetsApiURLWithRef , r.URL.Path)
+		if r.URL.Path != testAssetsApiURLWithRef {
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
-		if r.Method !=  http.MethodPost {
-			t.Errorf("Expected a %s request , got: %s",http.MethodPost, r.Method)
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		var requestTag domain.Tag
+		// Try to decode the request body into the struct. If there is an error,
+		// respond to the client with the error message and a 400 status code.
+		err := json.NewDecoder(r.Body).Decode(&requestTag)
+		if err != nil || requestTag.Value == badTagValue {
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -63,7 +76,11 @@ func TestAddTagToAsset(t *testing.T) {
 	//Test invalid tag
 	badTagErr := assetsApi.AddNewTag(asset, "", "1")
 	assert.NotEqual(t, nil, badTagErr)
-	
+
+	//Test tag with -1 value to force bad request on POST
+	badPostErr := assetsApi.AddNewTag(asset, "Test", badTagValue)
+	assert.NotEqual(t, nil, badPostErr)
+
 	//Test asset with no Ref
 	badAsset := domain.Asset{
 		Id:   1,
@@ -77,12 +94,16 @@ func TestAddTagToAsset(t *testing.T) {
 }
 
 func TestDeleteTagFromAsset(t *testing.T) {
+	const validTagName = "Test"
+	const nonExistingTagName = "Test123"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path !=  testAssetsApiURLWithRef {
-			t.Errorf("Expected to request '%s', got: %s", testAssetsApiURLWithRef , r.URL.Path)
+		if r.URL.Path != fmt.Sprintf("%s/%s", testAssetsApiURLWithRef, validTagName) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
-		if r.Method !=  http.MethodDelete {
-			t.Errorf("Expected a %s request , got: %s",http.MethodDelete, r.Method)
+		if r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -106,10 +127,13 @@ func TestDeleteTagFromAsset(t *testing.T) {
 	assetErr := assetsApi.DeleteTag(asset, "Test")
 	assert.Equal(t, nil, assetErr)
 
-
 	//Test invalid tag
 	badTagErr := assetsApi.DeleteTag(asset, "")
 	assert.NotEqual(t, nil, badTagErr)
+
+	//Test non-existent tag and error on DELETE request
+	noTagExistsErr := assetsApi.DeleteTag(asset, "Test123")
+	assert.NotEqual(t, nil, noTagExistsErr)
 
 	//Test asset with no Ref
 	badAsset := domain.Asset{

--- a/pkg/starkapi/assets_api_test.go
+++ b/pkg/starkapi/assets_api_test.go
@@ -1,6 +1,7 @@
 package starkapi
 
 import (
+	"fmt"
 	"github.com/Stark-Tech-Group/stg-sdk-golang/pkg/domain"
 	"github.com/stretchr/testify/assert"
 	"net/http"
@@ -9,7 +10,8 @@ import (
 )
 
 const testHost =  "https://test.com"
-const testURLWithRef =  "/core/assets/e.test/tags"
+const testAssetsApiURL =  "/core/assets"
+const testAssetsApiURLWithRef =  "/core/assets/e.test/tags"
 
 func TestAssetsApi_HostUrl(t *testing.T) {
 	api := Client{}
@@ -19,10 +21,18 @@ func TestAssetsApi_HostUrl(t *testing.T) {
 	assert.Equal(t, testHost, assetsApi.host())
 }
 
+func TestAssetsApi_BaseUrl(t *testing.T) {
+	api := Client{}
+	host := testHost
+	api.Init(host)
+	assetsApi := api.AssetsApi
+	assert.Equal(t, fmt.Sprintf("%s%s", testHost, testAssetsApiURL), assetsApi.baseUrl())
+}
+
 func TestAddTagToAsset(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path !=  testURLWithRef {
-			t.Errorf("Expected to request '%s', got: %s", testURLWithRef , r.URL.Path)
+		if r.URL.Path !=  testAssetsApiURLWithRef {
+			t.Errorf("Expected to request '%s', got: %s", testAssetsApiURLWithRef , r.URL.Path)
 		}
 		if r.Method !=  http.MethodPost {
 			t.Errorf("Expected a %s request , got: %s",http.MethodPost, r.Method)
@@ -68,8 +78,8 @@ func TestAddTagToAsset(t *testing.T) {
 
 func TestDeleteTagFromAsset(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path !=  testURLWithRef {
-			t.Errorf("Expected to request '%s', got: %s", testURLWithRef , r.URL.Path)
+		if r.URL.Path !=  testAssetsApiURLWithRef {
+			t.Errorf("Expected to request '%s', got: %s", testAssetsApiURLWithRef , r.URL.Path)
 		}
 		if r.Method !=  http.MethodDelete {
 			t.Errorf("Expected a %s request , got: %s",http.MethodDelete, r.Method)


### PR DESCRIPTION
# Updates
- TSP-2540 Refactor GO SDK, to use httptest for legacy tests

### Important Notes
- Updated assets api tests to include base url.
- Changed assets api BaseUrl to baseUrl to make private.
- Added Asset_Tree_Api_Test class and initial tests.


