### PR TITLE
feature/TSP-2548_Fields

### DIFF
--- a/pkg/domain/form_control.go
+++ b/pkg/domain/form_control.go
@@ -1,0 +1,16 @@
+package domain
+
+type FormControlList struct {
+	Count  int32    `json:"count"`
+	FormControlList []*FormControl `json:"formControlList"`
+}
+
+type FormControl struct {
+	Id          int32      `json:"id,omitempty"`
+	Ref         string     `json:"ref,omitempty"`
+	Name        string     `json:"name"`
+	Enabled     bool       `json:"enabled,omitempty"`
+	Description string     `json:"description"`
+	Control 	string     `json:"string"`
+	Audit       *Audit     `json:"audit,omitempty"`
+}

--- a/pkg/domain/form_control_ref.go
+++ b/pkg/domain/form_control_ref.go
@@ -1,0 +1,21 @@
+package domain
+
+type FormControlRefList struct {
+	Count  int32    `json:"count"`
+	FormControlRefList []*FormControlRef `json:"formControlList"`
+}
+
+type FormControlRef struct {
+	Id          int32      	`json:"id,omitempty"`
+	Ref         string     	`json:"ref,omitempty"`
+	Name        string     	`json:"name"`
+	Enabled     bool       	`json:"enabled,omitempty"`
+	Description string     	`json:"description"`
+	FormControl string     	`json:"formControl"`
+	SortOrder 	int32     	`json:"order"`
+	Key 		string     	`json:"key"`
+	Value 		string     	`json:"value"`
+	TargetRef 	string     	`json:"targetRef"`
+	Audit       *Audit     	`json:"audit,omitempty"`
+}
+

--- a/pkg/starkapi/assets_api.go
+++ b/pkg/starkapi/assets_api.go
@@ -12,27 +12,34 @@ type AssetsApi struct {
 	client *Client
 }
 
+const invalidTagNameErrorStr = "invalid tag name"
+const invalidAssetErrorStr = "invalid asset"
+
 func (assetsApi *AssetsApi) host() string {
 	return assetsApi.client.host
 }
 
-func (assetsApi *AssetsApi) BaseUrl() string {
+func (assetsApi *AssetsApi) baseUrl() string {
 	return fmt.Sprintf("%s/core/assets", assetsApi.host())
 }
 
-func (assetsApi *AssetsApi) AddNewTag(asset domain.Asset, name string, value string) error {
-	if len(name) < 1 {
+func (assetsApi *AssetsApi) tagUrlWithRef(ref string) string {
+	return fmt.Sprintf("%s/%s/tags", assetsApi.baseUrl(), ref)
+}
+
+func (assetsApi *AssetsApi) AddNewTag(asset domain.Asset, tagName string, tagValue string) error {
+	if len(tagName) < 1 {
 		logger.Error("invalid tag name in assets/AddNewTag.")
-		return errors.New("invalid tag name")
+		return errors.New(invalidTagNameErrorStr)
 	}
 
 	if len(asset.Ref) < 1 {
 		logger.Error("invalid asset in assets/AddNewTag. Asset does not have a ref.")
-		return errors.New("invalid asset")
+		return errors.New(invalidAssetErrorStr)
 	}
 
-	url := fmt.Sprintf("%s/%v/tags", assetsApi.BaseUrl(), asset.Ref)
-	ask := domain.Tag{Name: name, Value: value}
+	url := assetsApi.tagUrlWithRef(asset.Ref)
+	ask := domain.Tag{Name: tagName, Value: tagValue}
 
 	body, err := json.Marshal(ask)
 	if err != nil {
@@ -55,17 +62,17 @@ func (assetsApi *AssetsApi) AddNewTags(asset domain.Asset, tags []domain.Tag) er
 
 	if len(asset.Ref) < 1 {
 		logger.Error("invalid asset in assets/AddNewTag. Asset does not have a ref.")
-		return errors.New("invalid asset")
+		return errors.New(invalidAssetErrorStr)
 	}
 
 	for _, element := range tags {
 		if len(element.Name) < 1 {
 			logger.Error("invalid tag name in assets/AddNewTags.")
-			return errors.New("invalid tag name")
+			return errors.New(invalidTagNameErrorStr)
 		}
 	}
 
-	url := fmt.Sprintf("%s/%v/tags", assetsApi.BaseUrl(), asset.Ref)
+	url := assetsApi.tagUrlWithRef(asset.Ref)
 
 	body, err := json.Marshal(tags)
 	if err != nil {
@@ -80,18 +87,18 @@ func (assetsApi *AssetsApi) AddNewTags(asset domain.Asset, tags []domain.Tag) er
 	return nil
 }
 
-func (assetsApi *AssetsApi) DeleteTag(asset domain.Asset, name string) error {
-	if len(name) < 1 {
+func (assetsApi *AssetsApi) DeleteTag(asset domain.Asset, tagName string) error {
+	if len(tagName) < 1 {
 		logger.Error("invalid tag name in assets/DeleteTag.")
-		return errors.New("invalid tag name")
+		return errors.New(invalidTagNameErrorStr)
 	}
 
 	if len(asset.Ref) < 1 {
 		logger.Error("invalid asset in assets/DeleteTag. Asset does not have a ref.")
-		return errors.New("invalid asset")
+		return errors.New(invalidAssetErrorStr)
 	}
 
-	url := fmt.Sprintf("%s/%v/tags", assetsApi.BaseUrl(), asset.Ref)
+	url := fmt.Sprintf("%s/%s", assetsApi.tagUrlWithRef(asset.Ref), tagName)
 
 	_, err := assetsApi.client.delete(url)
 	if err != nil {

--- a/pkg/starkapi/assets_api_test.go
+++ b/pkg/starkapi/assets_api_test.go
@@ -102,6 +102,63 @@ func TestAddTagToAsset(t *testing.T) {
 	assert.NotEqual(t, nil, badAssetErr)
 }
 
+func TestAddTagsToAsset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path !=  testAssetsApiURLWithRef {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.Method !=  http.MethodPost {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	api := Client{}
+	host := server.URL
+
+	api.Init(host)
+
+	//Test valid asset and tag array
+	asset := domain.Asset{
+		Id:   1,
+		Ref:  "e.test",
+		Name: "Test",
+		Type: "Equip",
+	}
+
+	var tags []domain.Tag
+	tags = append(tags, domain.Tag{Name: "Test", Value: "1"})
+
+	assetsApi := api.AssetsApi
+
+	assetErr := assetsApi.AddNewTags(asset, tags)
+	assert.Equal(t, nil, assetErr)
+
+	//Test Tag with no name
+	tags = append(tags, domain.Tag{Name: "", Value: "1"})
+	noNameTagErr := assetsApi.AddNewTags(asset, tags)
+	assert.NotEqual(t, nil, noNameTagErr)
+
+	//Test empty tag array
+	var emptyTags []domain.Tag
+	badTagErr := assetsApi.AddNewTags(asset, emptyTags)
+	assert.NotEqual(t, nil, badTagErr)
+
+	//Test asset with no Ref
+	badAsset := domain.Asset{
+		Id:   1,
+		Ref:  "",
+		Name: "",
+		Type: "Equip",
+	}
+
+	badAssetErr := assetsApi.AddNewTag(badAsset, "Test", "1")
+	assert.NotEqual(t, nil, badAssetErr)
+}
+
 func TestDeleteTagFromAsset(t *testing.T) {
 	const validTagName = "Test"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/starkapi/assets_api_test.go
+++ b/pkg/starkapi/assets_api_test.go
@@ -155,7 +155,7 @@ func TestAddTagsToAsset(t *testing.T) {
 		Type: "Equip",
 	}
 
-	badAssetErr := assetsApi.AddNewTag(badAsset, "Test", "1")
+	badAssetErr := assetsApi.AddNewTags(badAsset, tags)
 	assert.NotEqual(t, nil, badAssetErr)
 }
 

--- a/pkg/starkapi/assets_api_test.go
+++ b/pkg/starkapi/assets_api_test.go
@@ -1,6 +1,8 @@
 package starkapi
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/Stark-Tech-Group/stg-sdk-golang/pkg/domain"
 	"github.com/stretchr/testify/assert"
 	"net/http"
@@ -9,9 +11,11 @@ import (
 )
 
 const testHost =  "https://test.com"
-const testURLWithRef =  "/core/assets/e.test/tags"
+const testAssetsApiURL =  "/core/assets"
+const testAssetsApiURLWithRef =  "/core/assets/e.test/tags"
+const testAssetRef = "e.test"
 
-func TestAssetsApi_HostUrl(t *testing.T) {
+func TestAssetsApi_hostUrl(t *testing.T) {
 	api := Client{}
 	host := testHost
 	api.Init(host)
@@ -19,13 +23,41 @@ func TestAssetsApi_HostUrl(t *testing.T) {
 	assert.Equal(t, testHost, assetsApi.host())
 }
 
+func TestAssetsApi_baseUrl(t *testing.T) {
+	api := Client{}
+	host := testHost
+	api.Init(host)
+	assetsApi := api.AssetsApi
+	assert.Equal(t, fmt.Sprintf("%s%s", testHost, testAssetsApiURL), assetsApi.baseUrl())
+}
+
+func TestAssetsApi_tagUrlWithRef(t *testing.T) {
+	api := Client{}
+	host := testHost
+	api.Init(host)
+	assetsApi := api.AssetsApi
+	assert.Equal(t, fmt.Sprintf("%s%s", testHost, testAssetsApiURLWithRef), assetsApi.tagUrlWithRef(testAssetRef))
+}
+
 func TestAddTagToAsset(t *testing.T) {
+	const badTagValue = "-1"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path !=  testURLWithRef {
-			t.Errorf("Expected to request '%s', got: %s", testURLWithRef , r.URL.Path)
+		if r.URL.Path != testAssetsApiURLWithRef {
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
-		if r.Method !=  http.MethodPost {
-			t.Errorf("Expected a %s request , got: %s",http.MethodPost, r.Method)
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		var requestTag domain.Tag
+		// Try to decode the request body into the struct. If there is an error,
+		// respond to the client with the error message and a 400 status code.
+		err := json.NewDecoder(r.Body).Decode(&requestTag)
+		if err != nil || requestTag.Value == badTagValue {
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -53,61 +85,10 @@ func TestAddTagToAsset(t *testing.T) {
 	//Test invalid tag
 	badTagErr := assetsApi.AddNewTag(asset, "", "1")
 	assert.NotEqual(t, nil, badTagErr)
-	
-	//Test asset with no Ref
-	badAsset := domain.Asset{
-		Id:   1,
-		Ref:  "",
-		Name: "",
-		Type: "Equip",
-	}
 
-	badAssetErr := assetsApi.AddNewTag(badAsset, "Test", "1")
-	assert.NotEqual(t, nil, badAssetErr)
-}
-
-func TestAddTagsToAsset(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path !=  testURLWithRef {
-			t.Errorf("Expected to request '%s', got: %s", testURLWithRef , r.URL.Path)
-		}
-		if r.Method !=  http.MethodPost {
-			t.Errorf("Expected a %s request , got: %s",http.MethodPost, r.Method)
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	api := Client{}
-	host := server.URL
-
-	api.Init(host)
-
-	//Test valid asset and tag array
-	asset := domain.Asset{
-		Id:   1,
-		Ref:  "e.test",
-		Name: "Test",
-		Type: "Equip",
-	}
-
-	var tags []domain.Tag
-	tags = append(tags, domain.Tag{Name: "Test", Value: "1"})
-
-	assetsApi := api.AssetsApi
-
-	assetErr := assetsApi.AddNewTags(asset, tags)
-	assert.Equal(t, nil, assetErr)
-
-	//Test Tag with no name
-	tags = append(tags, domain.Tag{Name: "", Value: "1"})
-	noNameTagErr := assetsApi.AddNewTags(asset, tags)
-	assert.NotEqual(t, nil, noNameTagErr)
-
-	//Test empty tag array
-	var emptyTags []domain.Tag
-	badTagErr := assetsApi.AddNewTags(asset, emptyTags)
-	assert.NotEqual(t, nil, badTagErr)
+	//Test tag with -1 value to force bad request on POST
+	badPostErr := assetsApi.AddNewTag(asset, "Test", badTagValue)
+	assert.NotEqual(t, nil, badPostErr)
 
 	//Test asset with no Ref
 	badAsset := domain.Asset{
@@ -122,12 +103,15 @@ func TestAddTagsToAsset(t *testing.T) {
 }
 
 func TestDeleteTagFromAsset(t *testing.T) {
+	const validTagName = "Test"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path !=  testURLWithRef {
-			t.Errorf("Expected to request '%s', got: %s", testURLWithRef , r.URL.Path)
+		if r.URL.Path != fmt.Sprintf("%s/%s", testAssetsApiURLWithRef, validTagName) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
-		if r.Method !=  http.MethodDelete {
-			t.Errorf("Expected a %s request , got: %s",http.MethodDelete, r.Method)
+		if r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -151,10 +135,13 @@ func TestDeleteTagFromAsset(t *testing.T) {
 	assetErr := assetsApi.DeleteTag(asset, "Test")
 	assert.Equal(t, nil, assetErr)
 
-
 	//Test invalid tag
 	badTagErr := assetsApi.DeleteTag(asset, "")
 	assert.NotEqual(t, nil, badTagErr)
+
+	//Test non-existent tag and error on DELETE request
+	noTagExistsErr := assetsApi.DeleteTag(asset, "Test123")
+	assert.NotEqual(t, nil, noTagExistsErr)
 
 	//Test asset with no Ref
 	badAsset := domain.Asset{

--- a/pkg/starkapi/client.go
+++ b/pkg/starkapi/client.go
@@ -21,6 +21,7 @@ type Client struct {
 	GeoApi       GeoApi
 	UridApi      UridApi
 	TagApi       TagApi
+	FormsApi	 FormsApi
 	/**/
 	loginEndpoint authApi
 	auth          *response.AuthResponse
@@ -45,6 +46,7 @@ func (client *Client) Init(host string) *Client {
 	client.GeoApi = GeoApi{client: client}
 	client.UridApi = UridApi{client: client}
 	client.TagApi = TagApi{client: client}
+	client.FormsApi = FormsApi{client: client}
 
 	return client
 }

--- a/pkg/starkapi/forms_api.go
+++ b/pkg/starkapi/forms_api.go
@@ -40,20 +40,20 @@ func (formsApi *FormsApi) GetAllControls() (domain.FormControlList, error) {
 	return controls, nil
 }
 
-func (formsApi *FormsApi) GetAllControlsForAsset(ref string) (domain.FormControlList, error) {
+func (formsApi *FormsApi) GetAllControlsForAsset(ref string) (domain.FormControlRefList, error) {
 	url := fmt.Sprintf("%s/%s%s", formsApi.BaseUrl(), ref, formsApi.ControlsPrefix())
 
-	var assetControls domain.FormControlList
+	var assetControls domain.FormControlRefList
 
 	resp, err := formsApi.client.get(url)
 	if err != nil {
-		return controls, err
+		return assetControls, err
 	}
 
-	err = json.Unmarshal(resp, &controls)
+	err = json.Unmarshal(resp, &assetControls)
 	if err != nil {
-		return controls, err
+		return assetControls, err
 	}
 
-	return controls, nil
+	return assetControls, nil
 }

--- a/pkg/starkapi/forms_api.go
+++ b/pkg/starkapi/forms_api.go
@@ -32,9 +32,11 @@ func (formsApi *FormsApi) GetAllControls() (domain.FormControlList, error) {
 		return controls, err
 	}
 
-	err = json.Unmarshal(resp, &controls)
-	if err != nil {
-		return controls, err
+	if len(resp) > 0 {
+		err = json.Unmarshal(resp, &controls)
+		if err != nil {
+			return controls, err
+		}
 	}
 
 	return controls, nil
@@ -50,9 +52,11 @@ func (formsApi *FormsApi) GetAllControlsForAsset(ref string) (domain.FormControl
 		return assetControls, err
 	}
 
-	err = json.Unmarshal(resp, &assetControls)
-	if err != nil {
-		return assetControls, err
+	if len(resp) > 0 {
+		err = json.Unmarshal(resp, &assetControls)
+		if err != nil {
+			return assetControls, err
+		}
 	}
 
 	return assetControls, nil

--- a/pkg/starkapi/forms_api.go
+++ b/pkg/starkapi/forms_api.go
@@ -14,16 +14,16 @@ func (formsApi *FormsApi) host() string {
 	return formsApi.client.host
 }
 
-func (formsApi *FormsApi) BaseUrl() string {
+func (formsApi *FormsApi) baseUrl() string {
 	return fmt.Sprintf("%s/core/forms", formsApi.host())
 }
 
-func (formsApi *FormsApi) ControlsPrefix() string {
+func (formsApi *FormsApi) controlsPrefix() string {
 	return fmt.Sprintf("/controls")
 }
 
 func (formsApi *FormsApi) GetAllControls() (domain.FormControlList, error) {
-	url := fmt.Sprintf("%s%s", formsApi.BaseUrl(), formsApi.ControlsPrefix())
+	url := fmt.Sprintf("%s%s", formsApi.baseUrl(), formsApi.controlsPrefix())
 
 	var controls domain.FormControlList
 
@@ -41,7 +41,7 @@ func (formsApi *FormsApi) GetAllControls() (domain.FormControlList, error) {
 }
 
 func (formsApi *FormsApi) GetAllControlsForAsset(ref string) (domain.FormControlRefList, error) {
-	url := fmt.Sprintf("%s/%s%s", formsApi.BaseUrl(), ref, formsApi.ControlsPrefix())
+	url := fmt.Sprintf("%s/%s%s", formsApi.baseUrl(), ref, formsApi.controlsPrefix())
 
 	var assetControls domain.FormControlRefList
 

--- a/pkg/starkapi/forms_api.go
+++ b/pkg/starkapi/forms_api.go
@@ -1,0 +1,59 @@
+package starkapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/Stark-Tech-Group/stg-sdk-golang/pkg/domain"
+)
+
+type FormsApi struct {
+	client *Client
+}
+
+func (formsApi *FormsApi) host() string {
+	return formsApi.client.host
+}
+
+func (formsApi *FormsApi) BaseUrl() string {
+	return fmt.Sprintf("%s/core/forms", formsApi.host())
+}
+
+func (formsApi *FormsApi) ControlsPrefix() string {
+	return fmt.Sprintf("/controls")
+}
+
+func (formsApi *FormsApi) GetAllControls() (domain.FormControlList, error) {
+	url := fmt.Sprintf("%s%s", formsApi.BaseUrl(), formsApi.ControlsPrefix())
+
+	var controls domain.FormControlList
+
+	resp, err := formsApi.client.get(url)
+	if err != nil {
+		return controls, err
+	}
+
+	err = json.Unmarshal(resp, &controls)
+	if err != nil {
+		return controls, err
+	}
+
+	return controls, nil
+}
+
+func (formsApi *FormsApi) GetAllControlsForAsset(ref string) (domain.FormControlList, error) {
+	url := fmt.Sprintf("%s/%s%s", formsApi.BaseUrl(), ref, formsApi.ControlsPrefix())
+
+	var assetControls domain.FormControlList
+
+	resp, err := formsApi.client.get(url)
+	if err != nil {
+		return controls, err
+	}
+
+	err = json.Unmarshal(resp, &controls)
+	if err != nil {
+		return controls, err
+	}
+
+	return controls, nil
+}

--- a/pkg/starkapi/forms_api_test.go
+++ b/pkg/starkapi/forms_api_test.go
@@ -1,0 +1,46 @@
+package starkapi
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const testFormsApiURL =  "/core/forms"
+const testFormsApiURLWithRef =  "/core/forms/e.test/controls"
+
+func TestFormsApi_host(t *testing.T) {
+	api := Client{}
+	host := testHost
+	api.Init(host)
+	formsApi := api.FormsApi
+	assert.Equal(t, testHost, formsApi.host())
+}
+
+func TestFormsApi_baseUrl(t *testing.T) {
+	api := Client{}
+	host := testHost
+	api.Init(host)
+	formsApi := api.FormsApi
+	assert.Equal(t, fmt.Sprintf("%s%s", testHost, testFormsApiURL), formsApi.baseUrl())
+}
+
+func TestFormsApi_controlsPrefix(t *testing.T) {
+	api := Client{}
+	host := testHost
+	api.Init(host)
+	formsApi := api.FormsApi
+	assert.Equal(t, "/controls", formsApi.controlsPrefix())
+}
+
+func TestFormsApi_GetAllControls(t *testing.T) {
+	api := Client{}
+	host := testHost
+	api.Init(host)
+	assetsApi := api.AssetsApi
+	assert.Equal(t, testHost, assetsApi.host())
+}
+
+func TestFormsApi_GetAllControlsForAsset(t *testing.T) {
+
+}

--- a/pkg/starkapi/forms_api_test.go
+++ b/pkg/starkapi/forms_api_test.go
@@ -3,11 +3,13 @@ package starkapi
 import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
 const testFormsApiURL =  "/core/forms"
-const testFormsApiURLWithRef =  "/core/forms/e.test/controls"
+const testFormsControlPrefix =  "/controls"
 
 func TestFormsApi_host(t *testing.T) {
 	api := Client{}
@@ -30,17 +32,70 @@ func TestFormsApi_controlsPrefix(t *testing.T) {
 	host := testHost
 	api.Init(host)
 	formsApi := api.FormsApi
-	assert.Equal(t, "/controls", formsApi.controlsPrefix())
+	assert.Equal(t, testFormsControlPrefix, formsApi.controlsPrefix())
 }
 
 func TestFormsApi_GetAllControls(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != fmt.Sprintf("%s%s", testFormsApiURL, testFormsControlPrefix) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
 	api := Client{}
-	host := testHost
+	host := server.URL
+
 	api.Init(host)
-	assetsApi := api.AssetsApi
-	assert.Equal(t, testHost, assetsApi.host())
+
+	formsApi := api.FormsApi
+
+	_, formsErr := formsApi.GetAllControls()
+	assert.Equal(t, nil, formsErr)
+
+	badApi := Client{}
+	badApi.Init("/bad")
+
+	badFormsApi := badApi.FormsApi
+	_, badFormsApiErr := badFormsApi.GetAllControls()
+	assert.NotEqual(t, nil, badFormsApiErr)
 }
 
 func TestFormsApi_GetAllControlsForAsset(t *testing.T) {
+	const assetRef = "e.test"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != fmt.Sprintf("%s/%s%s", testFormsApiURL, assetRef, testFormsControlPrefix) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
 
+	api := Client{}
+	host := server.URL
+
+	api.Init(host)
+
+	formsApi := api.FormsApi
+
+	_, formsErr := formsApi.GetAllControlsForAsset(assetRef)
+	assert.Equal(t, nil, formsErr)
+
+	badApi := Client{}
+	badApi.Init("/bad")
+
+	badFormsApi := badApi.FormsApi
+	_, badFormsApiErr := badFormsApi.GetAllControlsForAsset(assetRef)
+	assert.NotEqual(t, nil, badFormsApiErr)
 }


### PR DESCRIPTION
# Updates
- TSP-2548 As a Go SDK user, I can get fields for an asset

### Important Notes
- Added new formControl and formControlRef domain objects.
-  Added get methods for get all form controls, and get all form fields by ref for an asset.
- Added tests for new class implementations.
- Fixed minor issues with Asset_Api and updated tests.
- Cleaned up code smells.
