### PR TITLE
helpers for context and json errors

### DIFF
--- a/pkg/context/context-helper.go
+++ b/pkg/context/context-helper.go
@@ -1,0 +1,35 @@
+package context
+
+import (
+	"context"
+	"errors"
+	"strconv"
+)
+
+const (
+	personId = "personId"
+)
+
+func ParseContextPersonId(ctx context.Context) (int64, error) {
+
+	val := ctx.Value(personId)
+	var id int64
+	switch val.(type) {
+	case bool:
+		return id, errors.New("unsupported type conversion bool -> int64")
+	case int:
+		return int64(val.(int)), nil
+	case int32:
+		return int64(val.(int32)), nil
+	case int64:
+		return val.(int64), nil
+	case float32:
+		return int64(val.(float32)), nil
+	case float64:
+		return int64(val.(float64)), nil
+	case string:
+		return strconv.ParseInt(val.(string), 10, 64)
+	}
+
+	return id, errors.New("unsupported type conversion")
+}

--- a/pkg/context/context-helper_test.go
+++ b/pkg/context/context-helper_test.go
@@ -1,0 +1,75 @@
+package context
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParseContextPersonId_WithString(t *testing.T) {
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, personId, "100")
+
+	expectedId := int64(100)
+	actualId, err := ParseContextPersonId(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedId, actualId)
+
+}
+
+func TestParseContextPersonId_WithFloat64(t *testing.T) {
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, personId, float64(100))
+
+	expectedId := int64(100)
+	actualId, err := ParseContextPersonId(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedId, actualId)
+
+}
+
+func TestParseContextPersonId_WithInt64(t *testing.T) {
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, personId, int64(100))
+
+	expectedId := int64(100)
+	actualId, err := ParseContextPersonId(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedId, actualId)
+
+}
+
+func TestParseContextPersonId_WithInt(t *testing.T) {
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, personId, int(100))
+
+	expectedId := int64(100)
+	actualId, err := ParseContextPersonId(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedId, actualId)
+
+}
+
+func TestParseContextPersonId_WithInt32(t *testing.T) {
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, personId, int32(100))
+
+	expectedId := int64(100)
+	actualId, err := ParseContextPersonId(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedId, actualId)
+
+}
+
+func TestParseContextPersonId_WithNone(t *testing.T) {
+
+	ctx := context.Background()
+	_, err := ParseContextPersonId(ctx)
+	assert.NotNil(t, err)
+
+}

--- a/pkg/http/errors.go
+++ b/pkg/http/errors.go
@@ -1,0 +1,23 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type jsonError struct {
+	Code  int
+	Error string
+}
+
+//JSONError writes a simple json formatted error
+func JSONError(w http.ResponseWriter, err string, code int) {
+	template := jsonError{}
+	template.Code = code
+	template.Error = err
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(template)
+}

--- a/pkg/http/errors_test.go
+++ b/pkg/http/errors_test.go
@@ -1,0 +1,25 @@
+package http
+
+import (
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestName(t *testing.T) {
+	//req := httptest.NewRequest(http.MethodGet, "/someplace", nil)
+	w := httptest.NewRecorder()
+
+	JSONError(w, "hello world", 400)
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+	expected := "{\"Code\":400,\"Error\":\"hello world\"}\n"
+	if string(data) != expected {
+		t.Errorf("expected [%s] got [%v]", expected, string(data))
+	}
+
+}


### PR DESCRIPTION
# Updates
- #TSP-2663 
- use `JsonError `for pretty json error messages instead of plain text message
- use `ParseContextPersonId` to more easily get the personId from a context 


### Important Notes
- None at this time

