### PR TITLE
TSP-2910_UpdateQueryParamMathOperators

### DIFF
--- a/pkg/domain/telemetry-message_test.go
+++ b/pkg/domain/telemetry-message_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestSetValue(t *testing.T) {
+func TestTelemetryMessageSetValue(t *testing.T) {
 	m := NewTelemetryMessage("abc")
 	m.SetValue("a-value", 100.0)
 	m.SetValue("b-value", 200.0)

--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -17,15 +17,16 @@ const (
 	where           = " where "
 	and             = " and "
 	defaultOperator = "="
+	leftOp          = "<"
 )
 
 var operatorMap = map[string]string{
-	"[eq]": "=",
-	"[nq]": "!=",
-	"[gt]": ">",
-	"[ge]": ">=",
-	"[lt]": "<",
-	"[le]": "<=",
+	"<eq>": "=",
+	"<nq>": "!=",
+	"<gt>": ">",
+	"<ge>": ">=",
+	"<lt>": "<",
+	"<le>": "<=",
 }
 var input = regexp.MustCompile("^([a-z]|[A-Z]|[0-9]|[.]|-){1,75}$")
 
@@ -79,7 +80,8 @@ func (q *QueryParams) Validate() bool {
 func decodeRightSide(field *reflect.StructField, val string) (string, interface{}, error) {
 
 	var operator, raw string
-	if val[0:1] == "[" && len(val) > 4 {
+
+	if val[0:1] == leftOp && len(val) > 4 {
 		queryOp := val[0:4]
 		operator = operatorMap[queryOp]
 		raw = val[4:]

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -53,7 +53,7 @@ func TestQueryParams_DecodeParameters_WithDefaultOperator(t *testing.T) {
 }
 
 func TestQueryParams_DecodeParameters_WithEqual(t *testing.T) {
-	p := QueryParams{Id: "[eq]1"}
+	p := QueryParams{Id: "<eq>1"}
 	parameters, err := p.DecodeParameters()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(parameters))
@@ -64,7 +64,7 @@ func TestQueryParams_DecodeParameters_WithEqual(t *testing.T) {
 }
 
 func TestQueryParams_DecodeParameters_WithNotEqual(t *testing.T) {
-	p := QueryParams{Id: "[nq]1"}
+	p := QueryParams{Id: "<nq>1"}
 	parameters, err := p.DecodeParameters()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(parameters))
@@ -75,7 +75,7 @@ func TestQueryParams_DecodeParameters_WithNotEqual(t *testing.T) {
 }
 
 func TestQueryParams_DecodeParameters_WithGreaterThan(t *testing.T) {
-	p := QueryParams{Id: "[gt]1"}
+	p := QueryParams{Id: "<gt>1"}
 	parameters, err := p.DecodeParameters()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(parameters))
@@ -86,7 +86,7 @@ func TestQueryParams_DecodeParameters_WithGreaterThan(t *testing.T) {
 }
 
 func TestQueryParams_DecodeParameters_WithGreaterThanEqual(t *testing.T) {
-	p := QueryParams{Id: "[ge]1"}
+	p := QueryParams{Id: "<ge>1"}
 	parameters, err := p.DecodeParameters()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(parameters))
@@ -97,7 +97,7 @@ func TestQueryParams_DecodeParameters_WithGreaterThanEqual(t *testing.T) {
 }
 
 func TestQueryParams_DecodeParameters_WithLessThan(t *testing.T) {
-	p := QueryParams{Id: "[lt]1"}
+	p := QueryParams{Id: "<lt>1"}
 	parameters, err := p.DecodeParameters()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(parameters))
@@ -108,7 +108,7 @@ func TestQueryParams_DecodeParameters_WithLessThan(t *testing.T) {
 }
 
 func TestQueryParams_DecodeParameters_WithLessThanEqual(t *testing.T) {
-	p := QueryParams{Id: "[le]1"}
+	p := QueryParams{Id: "<le>1"}
 	parameters, err := p.DecodeParameters()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(parameters))
@@ -119,7 +119,7 @@ func TestQueryParams_DecodeParameters_WithLessThanEqual(t *testing.T) {
 }
 
 func TestQueryParams_DecodeAll_Case1(t *testing.T) {
-	p := QueryParams{SiteRef: "[eq]s.abc", EquipId: "[gt]100"}
+	p := QueryParams{SiteRef: "<eq>s.abc", EquipId: "<gt>100"}
 	parameters, err := p.DecodeParameters()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(parameters))
@@ -134,7 +134,7 @@ func TestQueryParams_DecodeAll_Case1(t *testing.T) {
 }
 
 func TestQueryParams_DecodeAll_Case2(t *testing.T) {
-	p := QueryParams{SiteRef: "[eq]s.abc", Id: "[nq]100"}
+	p := QueryParams{SiteRef: "<eq>s.abc", Id: "<nq>100"}
 	parameters, err := p.DecodeParameters()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(parameters))


### PR DESCRIPTION
# Updates
- #TSP-2910 Change QueryParam operators from "[ ]" to "< >"

### Important Notes
- Grails crashes if you pass "[" or "{" in the query params as it reads it as a map or array
- TDS requires updates
