### PR TITLE
feature/TSP-3007

### DIFF
--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -181,9 +181,7 @@ func (q *QueryParams) BuildParameterizedQuery(sql string) (string, []interface{}
 
 	if q.SortA != "" {
 		b.WriteString(fmt.Sprintf(" ORDER BY %s ASC", q.SortA))
-	}
-
-	if q.SortD != "" {
+	} else if q.SortD != "" {
 		b.WriteString(fmt.Sprintf(" ORDER BY %s DESC", q.SortD))
 	}
 

--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -202,7 +202,7 @@ func (q *QueryParams) BuildParameterizedQuery(sql string) (string, []interface{}
 			b.WriteString(p.parameterizedClause(i + 1))
 			if i < len(parameters)-1 && !parameters[i+1].AscSort && !parameters[i+1].DescSort {
 				b.WriteString(and)
-			} else if parameters[i+1].AscSort || parameters[i+1].DescSort {
+			} else if i < len(parameters)-1 && (parameters[i+1].AscSort || parameters[i+1].DescSort) {
 				b.WriteString(orderBy)
 			}
 

--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -145,7 +145,7 @@ func (q *QueryParams) DecodeParameters() ([]Parameter, error) {
 		decorator := field.Tag.Get(sqlDecorator)
 		if len(val) > 0 {
 			if field.Name == "SortA" || field.Name == "SortD" {
-				sqlTag := q.FindSqlColumn(t, val)
+				sqlTag := q.findSqlColumn(t, val)
 				operator, sqlValue, err := decodeRightSide(&field, sqlTag)
 				if err != nil {
 					return nil, err
@@ -171,7 +171,7 @@ func (q *QueryParams) DecodeParameters() ([]Parameter, error) {
 	return clauses, nil
 }
 
-func (q *QueryParams) FindSqlColumn(t reflect.Type, sortVal string) string {
+func (q *QueryParams) findSqlColumn(t reflect.Type, sortVal string) string {
 	sqlTag := ""
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)

--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -49,11 +49,13 @@ type QueryParams struct {
 	Offset      int    `json:"offset" schema:"offset"`
 	RequestName string `json:"-" schema:"-"`
 	EventType   string `json:"eventType" schema:"eventType" sqlColumn:"event_type" sqlType:"text"`
+	SortA       string `json:"sortA" schema:"sortA"`
+	SortD       string `json:"sortD" schema:"sortD"`
 }
 
 // HashKey creates a compounded string of the current QueryParams
 func (q *QueryParams) HashKey() string {
-	return fmt.Sprintf("%s-%s-%s-%s-%s-%s-%s-%s-%s-%s-%s-%s-%s-%v-%v",
+	return fmt.Sprintf("%s-%s-%s-%s-%s-%s-%s-%s-%s-%s-%s-%s-%s-%v-%v-%s-%s",
 		q.RequestName,
 		q.Id,
 		q.Ref,
@@ -68,7 +70,9 @@ func (q *QueryParams) HashKey() string {
 		q.Ts,
 		q.EndTs,
 		q.Limit,
-		q.Offset)
+		q.Offset,
+		q.SortA,
+		q.SortD)
 }
 
 func (q *QueryParams) Validate() bool {
@@ -173,6 +177,14 @@ func (q *QueryParams) BuildParameterizedQuery(sql string) (string, []interface{}
 			b.WriteString(and)
 		}
 		args[i] = p.Value
+	}
+
+	if q.SortA != "" {
+		b.WriteString(fmt.Sprintf(" ORDER BY %s ASC", q.SortA))
+	}
+
+	if q.SortD != "" {
+		b.WriteString(fmt.Sprintf(" ORDER BY %s DESC", q.SortD))
 	}
 
 	if q.Limit > 0 {

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -7,39 +7,43 @@ import (
 
 func TestQueryParams_HashKey(t *testing.T) {
 	p := QueryParams{}
-	assert.Equal(t, "-------------0-0", p.HashKey())
+	assert.Equal(t, "-------------0-0--", p.HashKey())
 
-	assert.Equal(t, "-------------0-0", p.HashKey())
+	assert.Equal(t, "-------------0-0--", p.HashKey())
 	p.RequestName = "R"
-	assert.Equal(t, "R-------------0-0", p.HashKey())
+	assert.Equal(t, "R-------------0-0--", p.HashKey())
 	p.Id = "1"
-	assert.Equal(t, "R-1------------0-0", p.HashKey())
+	assert.Equal(t, "R-1------------0-0--", p.HashKey())
 	p.Ref = "2"
-	assert.Equal(t, "R-1-2-----------0-0", p.HashKey())
+	assert.Equal(t, "R-1-2-----------0-0--", p.HashKey())
 	p.SiteId = "3"
-	assert.Equal(t, "R-1-2-3----------0-0", p.HashKey())
+	assert.Equal(t, "R-1-2-3----------0-0--", p.HashKey())
 	p.SiteRef = "4"
-	assert.Equal(t, "R-1-2-3-4---------0-0", p.HashKey())
+	assert.Equal(t, "R-1-2-3-4---------0-0--", p.HashKey())
 	p.EquipRef = "5"
-	assert.Equal(t, "R-1-2-3-4-5--------0-0", p.HashKey())
+	assert.Equal(t, "R-1-2-3-4-5--------0-0--", p.HashKey())
 	p.RuleName = "6"
-	assert.Equal(t, "R-1-2-3-4-5-6-------0-0", p.HashKey())
+	assert.Equal(t, "R-1-2-3-4-5-6-------0-0--", p.HashKey())
 	p.RuleId = "7"
-	assert.Equal(t, "R-1-2-3-4-5-6-7------0-0", p.HashKey())
+	assert.Equal(t, "R-1-2-3-4-5-6-7------0-0--", p.HashKey())
 	p.Severity = "8"
-	assert.Equal(t, "R-1-2-3-4-5-6-7-8-----0-0", p.HashKey())
+	assert.Equal(t, "R-1-2-3-4-5-6-7-8-----0-0--", p.HashKey())
 	p.Duration = "9"
-	assert.Equal(t, "R-1-2-3-4-5-6-7-8-9----0-0", p.HashKey())
+	assert.Equal(t, "R-1-2-3-4-5-6-7-8-9----0-0--", p.HashKey())
 	p.PersonId = "10"
-	assert.Equal(t, "R-1-2-3-4-5-6-7-8-9-10---0-0", p.HashKey())
+	assert.Equal(t, "R-1-2-3-4-5-6-7-8-9-10---0-0--", p.HashKey())
 	p.Ts = "11"
-	assert.Equal(t, "R-1-2-3-4-5-6-7-8-9-10-11--0-0", p.HashKey())
+	assert.Equal(t, "R-1-2-3-4-5-6-7-8-9-10-11--0-0--", p.HashKey())
 	p.EndTs = "12"
-	assert.Equal(t, "R-1-2-3-4-5-6-7-8-9-10-11-12-0-0", p.HashKey())
+	assert.Equal(t, "R-1-2-3-4-5-6-7-8-9-10-11-12-0-0--", p.HashKey())
 	p.Limit = 13
-	assert.Equal(t, "R-1-2-3-4-5-6-7-8-9-10-11-12-13-0", p.HashKey())
+	assert.Equal(t, "R-1-2-3-4-5-6-7-8-9-10-11-12-13-0--", p.HashKey())
 	p.Offset = 14
-	assert.Equal(t, "R-1-2-3-4-5-6-7-8-9-10-11-12-13-14", p.HashKey())
+	assert.Equal(t, "R-1-2-3-4-5-6-7-8-9-10-11-12-13-14--", p.HashKey())
+	p.SortA = "ts"
+	assert.Equal(t, "R-1-2-3-4-5-6-7-8-9-10-11-12-13-14-ts-", p.HashKey())
+	p.SortD = "id"
+	assert.Equal(t, "R-1-2-3-4-5-6-7-8-9-10-11-12-13-14-ts-id", p.HashKey())
 }
 func TestQueryParams_DecodeParameters_WithDefaultOperator(t *testing.T) {
 	p := QueryParams{Id: "1"}
@@ -176,4 +180,60 @@ func TestQueryParams_build_sql(t *testing.T) {
 	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) LIMIT 5000", sql)
 	assert.Equal(t, 4, len(args))
 
+}
+
+func TestQueryParams_build_sql_SortA(t *testing.T) {
+	p := QueryParams{SiteRef: "<eq>s.abc", Id: "<nq>100", Ts: "1666797079", EndTs: "1666797080", SortA: "end_ts"}
+	parameters, err := p.DecodeParameters()
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(parameters))
+
+	assert.Equal(t, "id", parameters[0].Column)
+	assert.Equal(t, "!=", parameters[0].Operator)
+	assert.Equal(t, int64(100), parameters[0].Value)
+
+	assert.Equal(t, "site_ref", parameters[1].Column)
+	assert.Equal(t, "=", parameters[1].Operator)
+	assert.Equal(t, "s.abc", parameters[1].Value)
+
+	assert.Equal(t, "ts", parameters[2].Column)
+	assert.Equal(t, "=", parameters[2].Operator)
+	assert.Equal(t, int64(1666797079), parameters[2].Value)
+
+	assert.Equal(t, "end_ts", parameters[3].Column)
+	assert.Equal(t, "=", parameters[3].Operator)
+	assert.Equal(t, int64(1666797080), parameters[3].Value)
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) ORDER BY end_ts ASC LIMIT 5000", sql)
+	assert.Equal(t, 4, len(args))
+}
+
+func TestQueryParams_build_sql_SortD(t *testing.T) {
+	p := QueryParams{SiteRef: "<eq>s.abc", Id: "<nq>100", Ts: "1666797079", EndTs: "1666797080", SortD: "end_ts"}
+	parameters, err := p.DecodeParameters()
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(parameters))
+
+	assert.Equal(t, "id", parameters[0].Column)
+	assert.Equal(t, "!=", parameters[0].Operator)
+	assert.Equal(t, int64(100), parameters[0].Value)
+
+	assert.Equal(t, "site_ref", parameters[1].Column)
+	assert.Equal(t, "=", parameters[1].Operator)
+	assert.Equal(t, "s.abc", parameters[1].Value)
+
+	assert.Equal(t, "ts", parameters[2].Column)
+	assert.Equal(t, "=", parameters[2].Operator)
+	assert.Equal(t, int64(1666797079), parameters[2].Value)
+
+	assert.Equal(t, "end_ts", parameters[3].Column)
+	assert.Equal(t, "=", parameters[3].Operator)
+	assert.Equal(t, int64(1666797080), parameters[3].Value)
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) ORDER BY end_ts DESC LIMIT 5000", sql)
+	assert.Equal(t, 4, len(args))
 }

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -237,3 +237,31 @@ func TestQueryParams_build_sql_SortD(t *testing.T) {
 	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) ORDER BY end_ts DESC LIMIT 5000", sql)
 	assert.Equal(t, 4, len(args))
 }
+
+func TestQueryParams_build_sql_SortAandSortD(t *testing.T) {
+	p := QueryParams{SiteRef: "<eq>s.abc", Id: "<nq>100", Ts: "1666797079", EndTs: "1666797080", SortA: "end_ts", SortD: "end_ts"}
+	parameters, err := p.DecodeParameters()
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(parameters))
+
+	assert.Equal(t, "id", parameters[0].Column)
+	assert.Equal(t, "!=", parameters[0].Operator)
+	assert.Equal(t, int64(100), parameters[0].Value)
+
+	assert.Equal(t, "site_ref", parameters[1].Column)
+	assert.Equal(t, "=", parameters[1].Operator)
+	assert.Equal(t, "s.abc", parameters[1].Value)
+
+	assert.Equal(t, "ts", parameters[2].Column)
+	assert.Equal(t, "=", parameters[2].Operator)
+	assert.Equal(t, int64(1666797079), parameters[2].Value)
+
+	assert.Equal(t, "end_ts", parameters[3].Column)
+	assert.Equal(t, "=", parameters[3].Operator)
+	assert.Equal(t, int64(1666797080), parameters[3].Value)
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) ORDER BY end_ts ASC LIMIT 5000", sql)
+	assert.Equal(t, 4, len(args))
+}

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -183,10 +183,10 @@ func TestQueryParams_build_sql(t *testing.T) {
 }
 
 func TestQueryParams_build_sql_SortA(t *testing.T) {
-	p := QueryParams{SiteRef: "<eq>s.abc", Id: "<nq>100", Ts: "1666797079", EndTs: "1666797080", SortA: "end_ts"}
+	p := QueryParams{SiteRef: "<eq>s.abc", Id: "<nq>100", Ts: "1666797079", EndTs: "1666797080", SortA: "endTs"}
 	parameters, err := p.DecodeParameters()
 	assert.Nil(t, err)
-	assert.Equal(t, 4, len(parameters))
+	assert.Equal(t, 5, len(parameters))
 
 	assert.Equal(t, "id", parameters[0].Column)
 	assert.Equal(t, "!=", parameters[0].Operator)
@@ -206,15 +206,15 @@ func TestQueryParams_build_sql_SortA(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) ORDER BY end_ts ASC LIMIT 5000", sql)
-	assert.Equal(t, 4, len(args))
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts asc LIMIT 5000", sql)
+	assert.Equal(t, 5, len(args))
 }
 
 func TestQueryParams_build_sql_SortD(t *testing.T) {
-	p := QueryParams{SiteRef: "<eq>s.abc", Id: "<nq>100", Ts: "1666797079", EndTs: "1666797080", SortD: "end_ts"}
+	p := QueryParams{SiteRef: "<eq>s.abc", Id: "<nq>100", Ts: "1666797079", EndTs: "1666797080", SortD: "endTs"}
 	parameters, err := p.DecodeParameters()
 	assert.Nil(t, err)
-	assert.Equal(t, 4, len(parameters))
+	assert.Equal(t, 5, len(parameters))
 
 	assert.Equal(t, "id", parameters[0].Column)
 	assert.Equal(t, "!=", parameters[0].Operator)
@@ -234,15 +234,15 @@ func TestQueryParams_build_sql_SortD(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) ORDER BY end_ts DESC LIMIT 5000", sql)
-	assert.Equal(t, 4, len(args))
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts desc LIMIT 5000", sql)
+	assert.Equal(t, 5, len(args))
 }
 
 func TestQueryParams_build_sql_SortAandSortD(t *testing.T) {
-	p := QueryParams{SiteRef: "<eq>s.abc", Id: "<nq>100", Ts: "1666797079", EndTs: "1666797080", SortA: "end_ts", SortD: "end_ts"}
+	p := QueryParams{SiteRef: "<eq>s.abc", Id: "<nq>100", Ts: "1666797079", EndTs: "1666797080", SortA: "endTs", SortD: "endTs"}
 	parameters, err := p.DecodeParameters()
 	assert.Nil(t, err)
-	assert.Equal(t, 4, len(parameters))
+	assert.Equal(t, 6, len(parameters))
 
 	assert.Equal(t, "id", parameters[0].Column)
 	assert.Equal(t, "!=", parameters[0].Operator)
@@ -262,6 +262,6 @@ func TestQueryParams_build_sql_SortAandSortD(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) ORDER BY end_ts ASC LIMIT 5000", sql)
-	assert.Equal(t, 4, len(args))
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts asc LIMIT 5000", sql)
+	assert.Equal(t, 6, len(args))
 }


### PR DESCRIPTION
# Updates
- TSP-3007 Order by support for queryParam by a single field

### Important Notes
- Added SortA and SortD fields to QueryParams struct
- BuildParameterizedQuery adds " ORDER BY [q.SortA] ASC" or "ORDER BY [q.SortD] DESC" accordingly

