### PR TITLE
Feature/tsp 3007 order by support

### DIFF
--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -206,7 +206,7 @@ func TestQueryParams_build_sql_SortA(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts asc LIMIT 5000", sql)
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by $5 asc LIMIT 5000", sql)
 	assert.Equal(t, 5, len(args))
 }
 
@@ -234,7 +234,7 @@ func TestQueryParams_build_sql_SortD(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts desc LIMIT 5000", sql)
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by $5 desc LIMIT 5000", sql)
 	assert.Equal(t, 5, len(args))
 }
 
@@ -242,7 +242,7 @@ func TestQueryParams_build_sql_SortAandSortD(t *testing.T) {
 	p := QueryParams{SiteRef: "<eq>s.abc", Id: "<nq>100", Ts: "1666797079", EndTs: "1666797080", SortA: "endTs", SortD: "endTs"}
 	parameters, err := p.DecodeParameters()
 	assert.Nil(t, err)
-	assert.Equal(t, 6, len(parameters))
+	assert.Equal(t, 5, len(parameters))
 
 	assert.Equal(t, "id", parameters[0].Column)
 	assert.Equal(t, "!=", parameters[0].Operator)
@@ -262,6 +262,6 @@ func TestQueryParams_build_sql_SortAandSortD(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts asc LIMIT 5000", sql)
-	assert.Equal(t, 6, len(args))
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by $5 asc LIMIT 5000", sql)
+	assert.Equal(t, 5, len(args))
 }


### PR DESCRIPTION
# Updates
- TSP-3007 Order by support for queryParam by a single field

### Important Notes
- Sql query generated now reads "ORDER BY $(arg number)" and then uses the appropriate argument generated by BuildParameterizedQuery

