### PR TITLE
Feature/tsp 3007 order by support

### DIFF
--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -207,12 +207,12 @@ func (q *QueryParams) BuildParameterizedQuery(sql string) (string, []interface{}
 			} else if i < len(parameters)-1 && (parameters[i+1].AscSort || parameters[i+1].DescSort) {
 				b.WriteString(orderBy)
 			}
+			args[i] = p.Value
 		} else if p.AscSort {
 			b.WriteString(p.parameterizedClause(i + 1))
 		} else if p.DescSort {
 			b.WriteString(p.parameterizedClause(i + 1))
 		}
-		args[i] = p.Value
 	}
 
 	if q.Limit > 0 {
@@ -240,9 +240,9 @@ func (p *Parameter) parameterizedClause(num int) string {
 		val = strings.Replace(p.Decorator, "%", fmt.Sprintf("$%d", num), 1)
 	}
 	if p.AscSort {
-		return fmt.Sprintf("%s asc", val)
+		return fmt.Sprintf("%s asc", p.Value)
 	} else if p.DescSort {
-		return fmt.Sprintf("%s desc", val)
+		return fmt.Sprintf("%s desc", p.Value)
 	}
 	return fmt.Sprintf("%s %s %s", p.Column, p.Operator, val)
 }

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -206,8 +206,9 @@ func TestQueryParams_build_sql_SortA(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by $5 asc LIMIT 5000", sql)
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts asc LIMIT 5000", sql)
 	assert.Equal(t, 5, len(args))
+	assert.Nil(t, args[4])
 }
 
 func TestQueryParams_build_sql_SortD(t *testing.T) {
@@ -234,8 +235,9 @@ func TestQueryParams_build_sql_SortD(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by $5 desc LIMIT 5000", sql)
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts desc LIMIT 5000", sql)
 	assert.Equal(t, 5, len(args))
+	assert.Nil(t, args[4])
 }
 
 func TestQueryParams_build_sql_SortAandSortD(t *testing.T) {
@@ -262,6 +264,7 @@ func TestQueryParams_build_sql_SortAandSortD(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by $5 asc LIMIT 5000", sql)
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts asc LIMIT 5000", sql)
 	assert.Equal(t, 5, len(args))
+	assert.Nil(t, args[4])
 }


### PR DESCRIPTION
# Updates
- TSP-3007 Order by support for queryParam by a single field

### Important Notes
- One more time with feeling
- Order by column name is no longer parameterized

