### PR TITLE
Feature/tsp 3007 order by support

### DIFF
--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -210,8 +210,12 @@ func (q *QueryParams) BuildParameterizedQuery(sql string) (string, []interface{}
 			args[i] = p.Value
 		} else if p.AscSort {
 			b.WriteString(p.parameterizedClause(i + 1))
+			args[i] = args[len(args)-1]
+			args = args[:len(args)-1]
 		} else if p.DescSort {
 			b.WriteString(p.parameterizedClause(i + 1))
+			args[i] = args[len(args)-1]
+			args = args[:len(args)-1]
 		}
 	}
 

--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -210,12 +210,10 @@ func (q *QueryParams) BuildParameterizedQuery(sql string) (string, []interface{}
 			args[i] = p.Value
 		} else if p.AscSort {
 			b.WriteString(p.parameterizedClause(i + 1))
-			args[i] = args[len(args)-1]
-			args = args[:len(args)-1]
+			args = append(args[:i], args[i+1:]...)
 		} else if p.DescSort {
 			b.WriteString(p.parameterizedClause(i + 1))
-			args[i] = args[len(args)-1]
-			args = args[:len(args)-1]
+			args = append(args[:i], args[i+1:]...)
 		}
 	}
 

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -207,8 +207,7 @@ func TestQueryParams_build_sql_SortA(t *testing.T) {
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
 	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts asc LIMIT 5000", sql)
-	assert.Equal(t, 5, len(args))
-	assert.Nil(t, args[4])
+	assert.Equal(t, 4, len(args))
 }
 
 func TestQueryParams_build_sql_SortD(t *testing.T) {
@@ -236,8 +235,7 @@ func TestQueryParams_build_sql_SortD(t *testing.T) {
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
 	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts desc LIMIT 5000", sql)
-	assert.Equal(t, 5, len(args))
-	assert.Nil(t, args[4])
+	assert.Equal(t, 4, len(args))
 }
 
 func TestQueryParams_build_sql_SortAandSortD(t *testing.T) {
@@ -265,6 +263,5 @@ func TestQueryParams_build_sql_SortAandSortD(t *testing.T) {
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
 	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts asc LIMIT 5000", sql)
-	assert.Equal(t, 5, len(args))
-	assert.Nil(t, args[4])
+	assert.Equal(t, 4, len(args))
 }


### PR DESCRIPTION
# Updates
- TSP-3007 Order by support for queryParam by a single field

### Important Notes
- Please god let this be the last one
- BuildParameterizedQuery now resizes args array if any of the parameters are sorts

