### PR TITLE
Feature/tsp 3422 remove default limit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/Azure/azure-event-hubs-go/v3 v3.3.18
+	github.com/lib/pq v1.10.7
 	github.com/sirupsen/logrus v1.2.0
 	github.com/stretchr/testify v1.7.4
 )
@@ -26,7 +27,6 @@ require (
 	github.com/joho/godotenv v1.4.0 // indirect
 	github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
-	github.com/lib/pq v1.10.7 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect

--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -187,7 +187,7 @@ func (q *QueryParams) findSqlColumn(t reflect.Type, sortVal string) string {
 	return sqlTag
 }
 
-//scan preforms a reflection lookup to populate internal collections for faster lookups
+// scan preforms a reflection lookup to populate internal collections for faster lookups
 func scan() {
 	if colTypeMap == nil || fieldToColumnMap == nil {
 
@@ -253,8 +253,6 @@ func (q *QueryParams) BuildParameterizedQuery(sql string) (string, []interface{}
 
 	if q.Limit > 0 {
 		b.WriteString(fmt.Sprintf(" LIMIT %v OFFSET %v", q.Limit, q.Offset))
-	} else {
-		b.WriteString(fmt.Sprintf(" LIMIT %v", maxLimit))
 	}
 
 	return b.String(), args, nil

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -190,7 +190,7 @@ func TestQueryParams_build_sql(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and profile_ref = $3 and ts = to_timestamp($4) and end_ts = to_timestamp($5) LIMIT 5000", sql)
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and profile_ref = $3 and ts = to_timestamp($4) and end_ts = to_timestamp($5)", sql)
 	assert.Equal(t, 5, len(args))
 
 }
@@ -219,7 +219,7 @@ func TestQueryParams_build_sql_SortA(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts asc LIMIT 5000", sql)
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts asc", sql)
 	assert.Equal(t, 4, len(args))
 }
 
@@ -247,7 +247,7 @@ func TestQueryParams_build_sql_SortD(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts desc LIMIT 5000", sql)
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts desc", sql)
 	assert.Equal(t, 4, len(args))
 }
 
@@ -275,7 +275,7 @@ func TestQueryParams_build_sql_SortAandSortD(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts asc LIMIT 5000", sql)
+	assert.Equal(t, "Select * from hello where id != $1 and site_ref = $2 and ts = to_timestamp($3) and end_ts = to_timestamp($4) order by end_ts asc", sql)
 	assert.Equal(t, 4, len(args))
 }
 
@@ -301,7 +301,7 @@ func TestQueryParams_WithIn(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where severity = ANY($1) LIMIT 5000", sql)
+	assert.Equal(t, "Select * from hello where severity = ANY($1)", sql)
 	assert.Equal(t, 1, len(args))
 
 }
@@ -324,7 +324,7 @@ func TestQueryParams_WithInAndEqual(t *testing.T) {
 
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 
-	assert.Equal(t, "Select * from hello where profile_ref = $1 and severity = ANY($2) LIMIT 5000", sql)
+	assert.Equal(t, "Select * from hello where profile_ref = $1 and severity = ANY($2)", sql)
 	assert.Equal(t, 2, len(args))
 	assert.Equal(t, "p.123", args[0])
 


### PR DESCRIPTION
# Updates
- TSP-3422 Remove default limit from golang sdk

### Important Notes
- Query param builder no longer sets a default limit

