### PR TITLE
feature/TSP-4810

### DIFF
--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -59,6 +59,7 @@ type QueryParams struct {
 	EventType   string `json:"eventType" schema:"eventType" sqlColumn:"event_type" sqlType:"text"`
 	SortA       string `json:"sortA" schema:"sortA"`
 	SortD       string `json:"sortD" schema:"sortD"`
+	DateCreated string `json:"dateCreated" schema:"dateCreated" sqlColumn:"date_created" sqlType:"bigint"`
 }
 
 // HashKey creates a compounded string of the current QueryParams

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -340,3 +340,25 @@ func TestQueryParams_WithInAndEqualAndSortAndLimitAndOffset(t *testing.T) {
 	assert.Equal(t, 3, len(args))
 	assert.Equal(t, "p.123", args[0])
 }
+
+func TestQueryParams_DateCreated(t *testing.T) {
+	p := QueryParams{DateCreated: "1683731908"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where date_created = $1", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, int64(1683731908), args[0])
+}
+
+func TestQueryParams_OrderByDateCreated(t *testing.T) {
+	p := QueryParams{Severity: "1", SortA: "dateCreated"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where severity = $1 order by date_created asc", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, int32(1), args[0])
+}

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -361,5 +361,4 @@ func TestQueryParams_OrderByDateCreated(t *testing.T) {
 	assert.Equal(t, "Select * from hello where severity = $1 order by date_created asc", sql)
 	assert.Equal(t, 1, len(args))
 	assert.Equal(t, int32(1), args[0])
-	//test
 }

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -361,4 +361,5 @@ func TestQueryParams_OrderByDateCreated(t *testing.T) {
 	assert.Equal(t, "Select * from hello where severity = $1 order by date_created asc", sql)
 	assert.Equal(t, 1, len(args))
 	assert.Equal(t, int32(1), args[0])
+	//test
 }


### PR DESCRIPTION
# Updates
- TSP-4810 Add Date Created to QueryParams in Go SDK

### Important Notes
- Added Date Created as a QueryParam

