### PR TITLE
feature/TSP-4816

### DIFF
--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -60,6 +60,7 @@ type QueryParams struct {
 	SortA       string `json:"sortA" schema:"sortA"`
 	SortD       string `json:"sortD" schema:"sortD"`
 	DateCreated string `json:"dateCreated" schema:"dateCreated" sqlColumn:"date_created" sqlType:"bigint"`
+	IssueStatus string `json:"issueStatus" schema:"issueStatus" sqlColumn:"issue_status_id" sqlType:"bigint"`
 }
 
 // HashKey creates a compounded string of the current QueryParams
@@ -228,7 +229,11 @@ func (q *QueryParams) BuildParameterizedQuery(sql string) (string, []interface{}
 	b := strings.Builder{}
 	b.WriteString(sql)
 	if len(parameters) > 0 {
-		b.WriteString(where)
+		if len(parameters) == 1 && (parameters[0].AscSort || parameters[0].DescSort) {
+			b.WriteString(orderBy)
+		} else {
+			b.WriteString(where)
+		}
 	}
 
 	explodedIndex := 0

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -362,3 +362,24 @@ func TestQueryParams_OrderByDateCreated(t *testing.T) {
 	assert.Equal(t, 1, len(args))
 	assert.Equal(t, int32(1), args[0])
 }
+
+func TestQueryParams_IssueStatus(t *testing.T) {
+	p := QueryParams{IssueStatus: "1"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where issue_status_id = $1", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, int64(1), args[0])
+}
+
+func TestQueryParams_OrderByIssueStatus(t *testing.T) {
+	p := QueryParams{SortA: "issueStatus"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello order by issue_status_id asc", sql)
+	assert.Equal(t, 0, len(args))
+}


### PR DESCRIPTION
# Updates
- TSP-4816 Add Issue Status to Go SDK Query Params

### Important Notes
- Added issue status to query params
- Fixed bug where BuildParameterizedQuery wrote "where" if the only parameter was a sort

