### PR TITLE
feature/TSP-4841

### DIFF
--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -22,8 +22,8 @@ const (
 	orderBy         = " order by "
 	in              = "IN"
 	pqArrayType     = ":pq-array"
-	startLike       = "like %s%%"
-	endLike         = "like %%%s"
+	startLike       = "like '%s%%'"
+	endLike         = "like '%%%s'"
 )
 
 var operatorMap = map[string]string{

--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -22,6 +22,8 @@ const (
 	orderBy         = " order by "
 	in              = "IN"
 	pqArrayType     = ":pq-array"
+	startLike       = "like %s%%"
+	endLike         = "like %%%s"
 )
 
 var operatorMap = map[string]string{
@@ -32,6 +34,8 @@ var operatorMap = map[string]string{
 	"<lt>": "<",
 	"<le>": "<=",
 	"<in>": in,
+	"<sw>": startLike,
+	"<ew>": endLike,
 }
 var input = regexp.MustCompile("^([a-z]|[A-Z]|[0-9]|[.]|-){1,75}$")
 var colTypeMap map[string]*reflect.StructField
@@ -293,6 +297,9 @@ func (p *Parameter) parameterizedClause(seedIndex int) (string, interface{}) {
 		//return p.parameterizedInClause(seedIndex + 1)
 		val := fmt.Sprintf("ANY($%d)", seedIndex+1)
 		return fmt.Sprintf("%s = %s", p.Column, val), nil
+	} else if p.Operator == startLike || p.Operator == endLike {
+		val := fmt.Sprintf(p.Operator, p.Value)
+		return fmt.Sprintf("%s %s", p.Column, val), nil
 	} else {
 		val := fmt.Sprintf("$%d", seedIndex+1)
 		if p.Decorator != "" {

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -415,3 +415,25 @@ func TestQueryParams_TargetRefOrderByDate(t *testing.T) {
 	assert.Equal(t, 1, len(args))
 	assert.Equal(t, "e.Ref", args[0])
 }
+
+func TestQueryParams_StartLike(t *testing.T) {
+	p := QueryParams{RuleName: "<sw>F"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where rule_name like F%", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, "F", args[0])
+}
+
+func TestQueryParams_EndLike(t *testing.T) {
+	p := QueryParams{RuleName: "<ew>F"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where rule_name like %F", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, "F", args[0])
+}

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -422,7 +422,7 @@ func TestQueryParams_StartLike(t *testing.T) {
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 	assert.Nil(t, err)
 
-	assert.Equal(t, "Select * from hello where rule_name like F%", sql)
+	assert.Equal(t, "Select * from hello where rule_name like 'F%'", sql)
 	assert.Equal(t, 1, len(args))
 	assert.Equal(t, "F", args[0])
 }
@@ -433,7 +433,7 @@ func TestQueryParams_EndLike(t *testing.T) {
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 	assert.Nil(t, err)
 
-	assert.Equal(t, "Select * from hello where rule_name like %F", sql)
+	assert.Equal(t, "Select * from hello where rule_name like '%F'", sql)
 	assert.Equal(t, 1, len(args))
 	assert.Equal(t, "F", args[0])
 }


### PR DESCRIPTION
# Updates
- TSP-4841 Like (Starts with and Ends with) support for queryParams

### Important Notes
- Implemented support for like queries through <sw> and <ew> operators

