### PR TITLE
bug/TSP-4863

### DIFF
--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -22,8 +22,8 @@ const (
 	orderBy         = " order by "
 	in              = "IN"
 	pqArrayType     = ":pq-array"
-	startLike       = "like '%s%%'"
-	endLike         = "like '%%%s'"
+	startLike       = "like %"
+	endLike         = "% like"
 )
 
 var operatorMap = map[string]string{
@@ -253,11 +253,7 @@ func (q *QueryParams) BuildParameterizedQuery(sql string) (string, []interface{}
 			chunk, _ := p.parameterizedClause(i + explodedIndex)
 
 			b.WriteString(chunk)
-			if p.Operator != startLike && p.Operator != endLike {
-				args = append(args, p.Value)
-			} else {
-				explodedIndex--
-			}
+			args = append(args, p.Value)
 
 			//evaluates the position current index for 'order by' and 'and'
 			if i < len(parameters)-1 && !parameters[i+1].AscSort && !parameters[i+1].DescSort {
@@ -301,9 +297,12 @@ func (p *Parameter) parameterizedClause(seedIndex int) (string, interface{}) {
 		//return p.parameterizedInClause(seedIndex + 1)
 		val := fmt.Sprintf("ANY($%d)", seedIndex+1)
 		return fmt.Sprintf("%s = %s", p.Column, val), nil
-	} else if p.Operator == startLike || p.Operator == endLike {
-		val := fmt.Sprintf(p.Operator, p.Value)
-		return fmt.Sprintf("%s %s", p.Column, val), nil
+	} else if p.Operator == startLike {
+		p.Value = "'" + p.Value.(string) + "%'"
+		return fmt.Sprintf("%s like $%d", p.Column, seedIndex+1), nil
+	} else if p.Operator == endLike {
+		p.Value = "'%" + p.Value.(string) + "'"
+		return fmt.Sprintf("%s like $%d", p.Column, seedIndex+1), nil
 	} else {
 		val := fmt.Sprintf("$%d", seedIndex+1)
 		if p.Decorator != "" {

--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -253,7 +253,11 @@ func (q *QueryParams) BuildParameterizedQuery(sql string) (string, []interface{}
 			chunk, _ := p.parameterizedClause(i + explodedIndex)
 
 			b.WriteString(chunk)
-			args = append(args, p.Value)
+			if p.Operator != startLike && p.Operator != endLike {
+				args = append(args, p.Value)
+			} else {
+				explodedIndex--
+			}
 
 			//evaluates the position current index for 'order by' and 'and'
 			if i < len(parameters)-1 && !parameters[i+1].AscSort && !parameters[i+1].DescSort {

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -423,8 +423,7 @@ func TestQueryParams_StartLike(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "Select * from hello where rule_name like 'F%'", sql)
-	assert.Equal(t, 1, len(args))
-	assert.Equal(t, "F", args[0])
+	assert.Equal(t, 0, len(args))
 }
 
 func TestQueryParams_EndLike(t *testing.T) {
@@ -434,6 +433,27 @@ func TestQueryParams_EndLike(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "Select * from hello where rule_name like '%F'", sql)
+	assert.Equal(t, 0, len(args))
+}
+
+func TestQueryParams_StartLikeWithEventType(t *testing.T) {
+	p := QueryParams{EventType: "<eq>open", RuleName: "<sw>F"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where rule_name like 'F%' and event_type = $1", sql)
 	assert.Equal(t, 1, len(args))
-	assert.Equal(t, "F", args[0])
+	assert.Equal(t, "open", args[0])
+}
+
+func TestQueryParams_EndLikeWithEventType(t *testing.T) {
+	p := QueryParams{EventType: "<eq>open", RuleName: "<ew>F"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where rule_name like '%F' and event_type = $1", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, "open", args[0])
 }

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -422,8 +422,9 @@ func TestQueryParams_StartLike(t *testing.T) {
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 	assert.Nil(t, err)
 
-	assert.Equal(t, "Select * from hello where rule_name like 'F%'", sql)
-	assert.Equal(t, 0, len(args))
+	assert.Equal(t, "Select * from hello where rule_name like $1", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, "'F%'", args[0])
 }
 
 func TestQueryParams_EndLike(t *testing.T) {
@@ -432,8 +433,9 @@ func TestQueryParams_EndLike(t *testing.T) {
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 	assert.Nil(t, err)
 
-	assert.Equal(t, "Select * from hello where rule_name like '%F'", sql)
-	assert.Equal(t, 0, len(args))
+	assert.Equal(t, "Select * from hello where rule_name like $1", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, "'%F'", args[0])
 }
 
 func TestQueryParams_StartLikeWithEventType(t *testing.T) {
@@ -442,9 +444,10 @@ func TestQueryParams_StartLikeWithEventType(t *testing.T) {
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 	assert.Nil(t, err)
 
-	assert.Equal(t, "Select * from hello where rule_name like 'F%' and event_type = $1", sql)
-	assert.Equal(t, 1, len(args))
-	assert.Equal(t, "open", args[0])
+	assert.Equal(t, "Select * from hello where rule_name like $1 and event_type = $2", sql)
+	assert.Equal(t, 2, len(args))
+	assert.Equal(t, "'F%'", args[0])
+	assert.Equal(t, "open", args[1])
 }
 
 func TestQueryParams_EndLikeWithEventType(t *testing.T) {
@@ -453,7 +456,8 @@ func TestQueryParams_EndLikeWithEventType(t *testing.T) {
 	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 	assert.Nil(t, err)
 
-	assert.Equal(t, "Select * from hello where rule_name like '%F' and event_type = $1", sql)
-	assert.Equal(t, 1, len(args))
-	assert.Equal(t, "open", args[0])
+	assert.Equal(t, "Select * from hello where rule_name like $1 and event_type = $2", sql)
+	assert.Equal(t, 2, len(args))
+	assert.Equal(t, "'%F'", args[0])
+	assert.Equal(t, "open", args[1])
 }


### PR DESCRIPTION
# Updates
- TSP-4863 Like statements throw off argument numbers in Go SDK

### Important Notes
- Like statements no longer throw off argument numbers

