### PR TITLE
bug/TSP-4994

### DIFF
--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -63,11 +63,11 @@ type QueryParams struct {
 	Offset      int    `json:"offset" schema:"offset"`
 	RequestName string `json:"-" schema:"-"`
 	EventType   string `json:"eventType" schema:"eventType" sqlColumn:"event_type" sqlType:"text"`
-	SortA       string `json:"sortA" schema:"sortA"`
-	SortD       string `json:"sortD" schema:"sortD"`
 	DateCreated string `json:"dateCreated" schema:"dateCreated" sqlColumn:"date_created" sqlType:"bigint"`
 	IssueStatus string `json:"issueStatus" schema:"issueStatus" sqlColumn:"issue_status_id" sqlType:"bigint"`
 	TargetRef   string `json:"targetRef" schema:"targetRef" sqlColumn:"target_ref" sqlType:"text"`
+	SortA       string `json:"sortA" schema:"sortA"`
+	SortD       string `json:"sortD" schema:"sortD"`
 }
 
 // HashKey creates a compounded string of the current QueryParams


### PR DESCRIPTION
# Updates
- TSP-4994 Go SDK puts query args after sort args for certain fields

### Important Notes
- Made it so that all parameterized argument fields appear before the SortA and SortD fields in QueryParams

