### PR TITLE
Added Seeding

### DIFF
--- a/pkg/domain/ref.go
+++ b/pkg/domain/ref.go
@@ -5,24 +5,25 @@ import (
 	"math/rand"
 	"regexp"
 	"strings"
+	"time"
 )
 
 const (
-	SiteRefType   = "s"
-	SiteTable     = "site"
-	EquipRefType  = "e"
-	EquipTable    = "equip"
-	PointRefType  = "p"
-	PointTable    = "point"
-	BranchRefType = "branch"
-	BranchTable   = "asset_tree_branch"
-	TagRefType    = "g"
-	TagRefTable   = "tag_ref"
-	alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
-	defaultLength = 16
-	defaultSpacing = 8
-	defaultSpacingChar = "-"
-	defaultPrefixChar = "."
+	SiteRefType            = "s"
+	SiteTable              = "site"
+	EquipRefType           = "e"
+	EquipTable             = "equip"
+	PointRefType           = "p"
+	PointTable             = "point"
+	BranchRefType          = "branch"
+	BranchTable            = "asset_tree_branch"
+	TagRefType             = "g"
+	TagRefTable            = "tag_ref"
+	alphabet               = "abcdefghijklmnopqrstuvwxyz0123456789"
+	defaultLength          = 16
+	defaultSpacing         = 8
+	defaultSpacingChar     = "-"
+	defaultPrefixChar      = "."
 	defaultPrefixMaxLength = 50
 )
 
@@ -30,6 +31,10 @@ var pattern = regexp.MustCompile(`^([a-z]{1,8}\.[a-z0-9]{8}-[a-z0-9]{8}([:]\d+)?
 
 type Ref struct {
 	Value string
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
 }
 
 //BeginsWith returns true if the current Ref HasPrefix of the provided value otherwise, false
@@ -56,22 +61,22 @@ func (r Ref) String() string {
 	return r.Value
 }
 
-func randomChar() string{
+func randomChar() string {
 	return string(alphabet[rand.Intn(len(alphabet))])
 }
 
-func RandomWithPrefix(prefix string) (string, error){
-	if len(prefix) < 1 ||  len(prefix) > defaultPrefixMaxLength {
+func RandomWithPrefix(prefix string) (string, error) {
+	if len(prefix) < 1 || len(prefix) > defaultPrefixMaxLength {
 		return "", fmt.Errorf("invalid prefix length")
 	}
 	return fmt.Sprintf("%s%s%s", prefix, defaultPrefixChar, random(defaultLength, defaultSpacing, defaultSpacingChar)), nil
 }
 
-func RandomWithoutPrefix() string{
+func RandomWithoutPrefix() string {
 	return random(defaultLength, defaultSpacing, defaultSpacingChar)
 }
 
-func random(length int, spacing int, spacerChar string) string{
+func random(length int, spacing int, spacerChar string) string {
 	var sb strings.Builder
 	spacer := 0
 	for length > 0 {

--- a/pkg/domain/ref_test.go
+++ b/pkg/domain/ref_test.go
@@ -49,3 +49,19 @@ func TestCreateRefWithoutPrefix(t *testing.T) {
 	a := Ref{Value: RandomWithoutPrefix()}
 	assert.Equal(t, defaultLength+len(defaultSpacingChar), len(a.Value))
 }
+
+func TestRandomWithoutPrefix_Over1MillionAttempts(t *testing.T) {
+	generatedStrings := make(map[string]struct{})
+
+	const numAttempts = 1000000
+
+	for i := 0; i < numAttempts; i++ {
+		s := RandomWithoutPrefix()
+
+		if _, exists := generatedStrings[s]; exists {
+			t.Fatalf("expected more random but found duplicate: %s", s)
+		}
+
+		generatedStrings[s] = struct{}{}
+	}
+}


### PR DESCRIPTION
# Updates
- #tsp-5123 seed random


### Important Notes
- In Go, if you do not explicitly set a seed for the math/rand package, it defaults to a fixed seed of 1. This means that every time you run your program, rand.Intn will produce the same sequence of numbers, leading your function to generate the same strings over and over again.