### PR TITLE
feature/TSP-5330

### DIFF
--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -313,8 +313,8 @@ func (p *Parameter) parameterizedClause(seedIndex int) (string, interface{}) {
 		p.Value = "%" + p.Value.(string)
 		return fmt.Sprintf("%s like $%d", p.Column, seedIndex+1), nil
 	} else {
-		if strings.Contains(p.Value.(string), "null") {
-			return fmt.Sprintf("%s = NULL", p.Column), nil
+		if p.Type == "string" && strings.Contains(p.Value.(string), "null") {
+			return fmt.Sprintf("%s IS NULL", p.Column), nil
 		}
 		val := fmt.Sprintf("$%d", seedIndex+1)
 		if p.Decorator != "" {

--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -180,6 +180,9 @@ func (q *QueryParams) DecodeParameters() ([]Parameter, error) {
 			tag := field.Tag.Get(sqlColumn)
 			if len(tag) > 0 {
 				operator, sqlValue, err := decodeRightSide(&field, val)
+				if sqlValue == "null" {
+					typ = "text"
+				}
 				if err != nil {
 					return nil, err
 				}
@@ -313,7 +316,7 @@ func (p *Parameter) parameterizedClause(seedIndex int) (string, interface{}) {
 		p.Value = "%" + p.Value.(string)
 		return fmt.Sprintf("%s like $%d", p.Column, seedIndex+1), nil
 	} else {
-		if p.Type == "string" && strings.Contains(p.Value.(string), "null") {
+		if p.Type == "text" && strings.Contains(p.Value.(string), "null") {
 			return fmt.Sprintf("%s IS NULL", p.Column), nil
 		}
 		val := fmt.Sprintf("$%d", seedIndex+1)

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -490,5 +490,5 @@ func TestQueryParams_NullValue(t *testing.T) {
 	sql, _, err := p.BuildParameterizedQuery("Select * from hello")
 	assert.Nil(t, err)
 
-	assert.Equal(t, "Select * from hello where issue_status_id = NULL", sql)
+	assert.Equal(t, "Select * from hello where issue_status_id IS NULL", sql)
 }

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -485,10 +485,22 @@ func TestQueryParams_EquipName(t *testing.T) {
 }
 
 func TestQueryParams_NullValue(t *testing.T) {
-	p := QueryParams{IssueStatus: "null"}
+	p := QueryParams{IssueStatus: nullVal}
 
 	sql, _, err := p.BuildParameterizedQuery("Select * from hello")
 	assert.Nil(t, err)
 
 	assert.Equal(t, "Select * from hello where issue_status_id IS NULL", sql)
+}
+
+func TestQueryParams_NullValueAndNonNull(t *testing.T) {
+	p := QueryParams{IssueStatus: nullVal, TargetRef: "a.Ref", SiteName: "aSite"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where site_name = $1 and issue_status_id IS NULL and target_ref = $2", sql)
+	assert.Equal(t, 2, len(args))
+	assert.Equal(t, "aSite", args[0])
+	assert.Equal(t, "a.Ref", args[1])
 }

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -483,3 +483,12 @@ func TestQueryParams_EquipName(t *testing.T) {
 	assert.Equal(t, 1, len(args))
 	assert.Equal(t, "anEquip", args[0])
 }
+
+func TestQueryParams_NullValue(t *testing.T) {
+	p := QueryParams{IssueStatus: "null"}
+
+	sql, _, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where issue_status_id = NULL", sql)
+}


### PR DESCRIPTION
# Updates
- TSP-5330 refactor goSDK to handle null comparisons

### Important Notes
- Entering "null" as a parameter value will now generate SQL like "WHERE [column] = NULL"

