### PR TITLE
feature/TSP-5330

### DIFF
--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -275,7 +275,9 @@ func (q *QueryParams) BuildParameterizedQuery(sql string) (string, []interface{}
 
 			b.WriteString(chunk)
 			if p.Operator == in {
-				args = append(args, pq.Array(p.Value.(arrayWithNull).values))
+				if len(p.Value.(arrayWithNull).values) > 0 {
+					args = append(args, pq.Array(p.Value.(arrayWithNull).values))
+				}
 			} else if p.Value != nil && p.Value != nullVal {
 				args = append(args, p.Value)
 			} else {

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -507,10 +507,11 @@ func TestQueryParams_NullValueAndNonNull(t *testing.T) {
 func TestQueryParams_InNullVal(t *testing.T) {
 	p := QueryParams{IssueStatus: "<in>null"}
 
-	sql, _, err := p.BuildParameterizedQuery("Select * from hello")
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
 	assert.Nil(t, err)
 
 	assert.Equal(t, "Select * from hello where issue_status_id IS NULL", sql)
+	assert.Equal(t, 0, len(args))
 }
 
 func TestQueryParams_InNullValAndNonNull(t *testing.T) {


### PR DESCRIPTION
# Updates
- TSP-5330 refactor goSDK to handle null comparisons

### Important Notes
- Made sure an arrayWithNull of size 0 is not being added as an argument for <in> null calls

