### PR TITLE
NewFormControlRef and NewRef funcs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/Azure/azure-event-hubs-go/v3 v3.3.18
 	github.com/lib/pq v1.10.7
-	github.com/sirupsen/logrus v1.2.0
+	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 )
 
@@ -26,11 +26,10 @@ require (
 	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
 	github.com/joho/godotenv v1.4.0 // indirect
 	github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7 // indirect
-	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
-	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -63,7 +63,6 @@ github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
 github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7 h1:K//n/AqR5HjG3qxbrBCL4vJPW0MVFSs9CPK1OOJdRME=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
-github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
@@ -74,8 +73,9 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -83,6 +83,7 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
@@ -99,8 +100,9 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/domain/form_control_ref.go
+++ b/pkg/domain/form_control_ref.go
@@ -1,21 +1,26 @@
 package domain
 
 type FormControlRefList struct {
-	Count  int32    `json:"count"`
+	Count              int32             `json:"count"`
 	FormControlRefList []*FormControlRef `json:"formControlList"`
 }
 
 type FormControlRef struct {
-	Id          int32      	`json:"id,omitempty"`
-	Ref         string     	`json:"ref,omitempty"`
-	Name        string     	`json:"name"`
-	Enabled     bool       	`json:"enabled,omitempty"`
-	Description string     	`json:"description"`
-	FormControl string     	`json:"formControl"`
-	SortOrder 	int32     	`json:"order"`
-	Key 		string     	`json:"key"`
-	Value 		string     	`json:"value"`
-	TargetRef 	string     	`json:"targetRef"`
-	Audit       *Audit     	`json:"audit,omitempty"`
+	Id          int32  `json:"id,omitempty"`
+	Ref         string `json:"ref,omitempty"`
+	Name        string `json:"name"`
+	Enabled     bool   `json:"enabled,omitempty"`
+	Description string `json:"description"`
+	FormControl string `json:"formControl"`
+	SortOrder   int32  `json:"order"`
+	Key         string `json:"key"`
+	Value       string `json:"value"`
+	TargetRef   string `json:"targetRef"`
+	Audit       *Audit `json:"audit,omitempty"`
 }
 
+func NewFormControlRef() *FormControlRef {
+	return &FormControlRef{
+		Ref: NewRef(FormControlRefTable),
+	}
+}

--- a/pkg/domain/form_control_ref_test.go
+++ b/pkg/domain/form_control_ref_test.go
@@ -1,0 +1,12 @@
+package domain
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewFormControlRef(t *testing.T) {
+	n := NewFormControlRef()
+	assert.NotNil(t, n)
+	assert.Equal(t, FormControlRefTable, n.Ref[0:1])
+}

--- a/pkg/domain/ref.go
+++ b/pkg/domain/ref.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 const (
@@ -19,6 +20,8 @@ const (
 	BranchTable            = "asset_tree_branch"
 	TagRefType             = "g"
 	TagRefTable            = "tag_ref"
+	FormControlTable       = "j"
+	FormControlRefTable    = "k"
 	alphabet               = "abcdefghijklmnopqrstuvwxyz0123456789"
 	defaultLength          = 16
 	defaultSpacing         = 8
@@ -37,17 +40,17 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-//BeginsWith returns true if the current Ref HasPrefix of the provided value otherwise, false
+// BeginsWith returns true if the current Ref HasPrefix of the provided value otherwise, false
 func (r *Ref) BeginsWith(prefix string) bool {
 	return strings.HasPrefix(r.Value, prefix)
 }
 
-//Valid returns true if the current Ref has a valid pattern
+// Valid returns true if the current Ref has a valid pattern
 func (r *Ref) Valid() bool {
 	return pattern.MatchString(r.Value)
 }
 
-//GetPrefix returns the all
+// GetPrefix returns the all
 func (r *Ref) GetPrefix() string {
 	if r.Valid() == false {
 		return ""
@@ -56,7 +59,7 @@ func (r *Ref) GetPrefix() string {
 	return strings.Split(r.Value, ".")[0]
 }
 
-//String returns the value
+// String returns the value
 func (r Ref) String() string {
 	return r.Value
 }
@@ -70,6 +73,21 @@ func RandomWithPrefix(prefix string) (string, error) {
 		return "", fmt.Errorf("invalid prefix length")
 	}
 	return fmt.Sprintf("%s%s%s", prefix, defaultPrefixChar, random(defaultLength, defaultSpacing, defaultSpacingChar)), nil
+}
+
+// NewRef generates a new reference string with the given prefix. The prefix is truncated
+// to a length of defaultPrefixMaxLength runes if it is longer. The remaining reference
+// string is generated using the RandomWithPrefix function.
+func NewRef(prefix string) string {
+	i := 0
+	n := defaultPrefixMaxLength
+	for i < len(prefix) && n > 0 {
+		_, size := utf8.DecodeRuneInString(prefix[i:])
+		i += size
+		n--
+	}
+	ref, _ := RandomWithPrefix(prefix[:i])
+	return ref
 }
 
 func RandomWithoutPrefix() string {

--- a/pkg/domain/ref_test.go
+++ b/pkg/domain/ref_test.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"strings"
 	"testing"
 )
 
@@ -63,5 +64,22 @@ func TestRandomWithoutPrefix_Over1MillionAttempts(t *testing.T) {
 		}
 
 		generatedStrings[s] = struct{}{}
+	}
+}
+
+func TestNewRef(t *testing.T) {
+	prefix := "Example"
+	ref := NewRef(prefix)
+
+	if !strings.HasPrefix(ref, prefix) {
+		t.Errorf("Expected reference to have prefix %s, but got %s", prefix, ref)
+	}
+
+	longPrefix := "ThisIsAVeryLongPrefixThatExceedsTheMaxLength"
+	expectedPrefix := longPrefix[:10]
+	refWithLongPrefix := NewRef(longPrefix)
+
+	if !strings.HasPrefix(refWithLongPrefix, expectedPrefix) {
+		t.Errorf("Expected reference to have truncated prefix %s, but got %s", expectedPrefix, refWithLongPrefix)
 	}
 }


### PR DESCRIPTION
# Updates
- supports #TSP-5442
- new NewFormControlRef 
- new NewRef
- Bump github.com/sirupsen/logrus from 1.2.0 to 1.9.3


