### PR TITLE
feature/TSP-5553_UpdateCreateFormControlMethod

### DIFF
--- a/pkg/domain/form_control.go
+++ b/pkg/domain/form_control.go
@@ -10,7 +10,7 @@ type FormControlList struct {
 }
 
 type FormControl struct {
-	Id          string `json:"id,omitempty"`
+	Id          int64  `json:"id,omitempty"`
 	Ref         string `json:"ref" validate:"required"`
 	Name        string `json:"name" validate:"required"`
 	Enabled     bool   `json:"enabled,omitempty"`

--- a/pkg/domain/form_control.go
+++ b/pkg/domain/form_control.go
@@ -10,13 +10,27 @@ type FormControlList struct {
 }
 
 type FormControl struct {
-	Id          int32  `json:"id,omitempty"`
-	Ref         string `json:"ref,omitempty" validate:"required"`
+	Id          string `json:"id,omitempty"`
+	Ref         string `json:"ref" validate:"required"`
 	Name        string `json:"name" validate:"required"`
 	Enabled     bool   `json:"enabled,omitempty"`
-	Description string `json:"description"`
-	Control     string `json:"string" validate:"required"`
-	Audit       *Audit `json:"audit,omitempty"`
+	Description string `json:"description,omitempty"`
+	Control     string `json:"control" validate:"required"`
+	ControlJSON struct {
+		Key             string `json:"key"`
+		Type            string `json:"type"`
+		TemplateOptions struct {
+			Label       string `json:"label"`
+			Placeholder string `json:"placeholder"`
+			Required    string `json:"required"`
+		} `json:"templateOptions,omitempty"`
+	} `json:"-,omitempty"`
+	Version string `json:"version,omitempty"`
+	Audit   *Audit `json:"audit,omitempty"`
+	Links   struct {
+		Type string `json:"type"`
+		Self string `json:"self"`
+	} `json:"links,omitempty"`
 }
 
 var validate *validator.Validate

--- a/pkg/domain/form_control.go
+++ b/pkg/domain/form_control.go
@@ -22,7 +22,7 @@ type FormControl struct {
 		TemplateOptions struct {
 			Label       string `json:"label"`
 			Placeholder string `json:"placeholder"`
-			Required    string `json:"required"`
+			Required    bool   `json:"required"`
 		} `json:"templateOptions,omitempty"`
 	} `json:"-,omitempty"`
 	Version string `json:"version,omitempty"`

--- a/pkg/domain/form_control_ref.go
+++ b/pkg/domain/form_control_ref.go
@@ -49,12 +49,12 @@ func (o *FormControlRef) ValidateStringParams(paramName string, errString string
 func (o *FormControlRef) BuildFormControlRefForCreate(formControl FormControl, ref string, value string) error {
 	err := formControl.Validate()
 	if err != nil {
-		logger.Error(err)
+		logger.Errorf("form control struct validate failed with error : [%s]", err)
 		return errors.New(fmt.Sprintf(errInvalidFormControl, formControl.Name))
 	}
 	err = json.Unmarshal([]byte(formControl.Control), &formControl.ControlJSON)
 	if err != nil {
-		logger.Error(err)
+		logger.Errorf("failed to unmarshall formControl.Control json with error : [%s]", err)
 		return err
 	}
 	o.TargetRef = ref
@@ -68,7 +68,7 @@ func (o *FormControlRef) BuildFormControlRefForCreate(formControl FormControl, r
 
 	err = validate.Struct(o)
 	if err != nil {
-		logger.Error(err)
+		logger.Errorf("form control ref struct validate failed with error : [%s]", err)
 		return err
 	}
 	return nil

--- a/pkg/domain/form_control_ref.go
+++ b/pkg/domain/form_control_ref.go
@@ -20,14 +20,14 @@ type FormControlRefList struct {
 }
 
 type FormControlRef struct {
-	Id            int32       `json:"id,omitempty"`
+	Id            int64       `json:"id,omitempty"`
 	TargetRef     string      `json:"targetRef" validate:"required"`
 	SortOrder     int32       `json:"sortOrder" validate:"required"`
 	Description   string      `json:"description" validate:"required"`
 	Name          string      `json:"name" validate:"required"`
 	Key           string      `json:"key" validate:"required"`
 	Value         string      `json:"value" validate:"required"`
-	FormControlId string      `json:"formControlId" validate:"required"`
+	FormControlId int64       `json:"formControlId" validate:"required"`
 	FormControl   FormControl `json:"formControl,omitempty"`
 	Audit         *Audit      `json:"audit,omitempty"`
 	Ref           string      `json:"ref,omitempty"`

--- a/pkg/domain/form_control_ref.go
+++ b/pkg/domain/form_control_ref.go
@@ -4,14 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	logger "github.com/sirupsen/logrus"
 )
 
 const (
-	errNoControlNameProvided = "please provide a form control name"
-	errNoRefProvided         = "please provide a ref"
-	errNoValueProvided       = "please provide a value"
-	errInvalidFormControl    = "invalid form control provided with name [%s]"
-	errInvalidFormControlRef = "unable to validate form control ref with information provided"
+	errInvalidFormControl = "invalid form control provided with name [%s]"
 )
 
 type FormControlRefList struct {
@@ -40,15 +37,10 @@ func NewFormControlRef() *FormControlRef {
 	}
 }
 
-func (o *FormControlRef) ValidateCreateRequireFields(formControlName string, ref string, value string) error {
-	if formControlName == "" {
-		return errors.New(errNoControlNameProvided)
-	}
-	if ref == "" {
-		return errors.New(errNoRefProvided)
-	}
-	if value == "" {
-		return errors.New(errNoValueProvided)
+func (o *FormControlRef) ValidateStringParams(paramName string, errString string) error {
+	if paramName == "" {
+		logger.Error(errors.New(errString))
+		return errors.New(errString)
 	}
 
 	return nil
@@ -57,11 +49,13 @@ func (o *FormControlRef) ValidateCreateRequireFields(formControlName string, ref
 func (o *FormControlRef) BuildFormControlRefForCreate(formControl FormControl, ref string, value string) error {
 	err := formControl.Validate()
 	if err != nil {
+		logger.Error(err)
 		return errors.New(fmt.Sprintf(errInvalidFormControl, formControl.Name))
 	}
 	err = json.Unmarshal([]byte(formControl.Control), &formControl.ControlJSON)
 	if err != nil {
-		return errors.New(fmt.Sprintf(errInvalidFormControl, formControl.Name))
+		logger.Error(err)
+		return err
 	}
 	o.TargetRef = ref
 	o.SortOrder = 1
@@ -74,7 +68,8 @@ func (o *FormControlRef) BuildFormControlRefForCreate(formControl FormControl, r
 
 	err = validate.Struct(o)
 	if err != nil {
-		return errors.New(errInvalidFormControlRef)
+		logger.Error(err)
+		return err
 	}
 	return nil
 }

--- a/pkg/domain/form_control_ref.go
+++ b/pkg/domain/form_control_ref.go
@@ -28,7 +28,7 @@ type FormControlRef struct {
 	Key           string      `json:"key" validate:"required"`
 	Value         string      `json:"value" validate:"required"`
 	FormControlId string      `json:"formControlId" validate:"required"`
-	FormControl   FormControl `json:"formControl, omitempty"`
+	FormControl   FormControl `json:"formControl,omitempty"`
 	Audit         *Audit      `json:"audit,omitempty"`
 	Ref           string      `json:"ref,omitempty"`
 	Version       int32       `json:"version,omitempty"`

--- a/pkg/domain/form_control_ref.go
+++ b/pkg/domain/form_control_ref.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	errInvalidFormControl = "invalid form control provided with name [%s]"
+	errInvalidFormControl = "form control struct validate failed for form control name [%s], with error : [%s]"
 )
 
 type FormControlRefList struct {
@@ -49,8 +49,9 @@ func (o *FormControlRef) ValidateStringParams(paramName string, errString string
 func (o *FormControlRef) BuildFormControlRefForCreate(formControl FormControl, ref string, value string) error {
 	err := formControl.Validate()
 	if err != nil {
-		logger.Errorf("form control struct validate failed with error : [%s]", err)
-		return errors.New(fmt.Sprintf(errInvalidFormControl, formControl.Name))
+		validateErr := errors.New(fmt.Sprintf(errInvalidFormControl, formControl.Name, err))
+		logger.Error(validateErr)
+		return validateErr
 	}
 	err = json.Unmarshal([]byte(formControl.Control), &formControl.ControlJSON)
 	if err != nil {

--- a/pkg/domain/form_control_ref.go
+++ b/pkg/domain/form_control_ref.go
@@ -1,26 +1,80 @@
 package domain
 
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+const (
+	errNoControlNameProvided = "please provide a form control name"
+	errNoRefProvided         = "please provide a ref"
+	errNoValueProvided       = "please provide a value"
+	errInvalidFormControl    = "invalid form control provided with name [%s]"
+	errInvalidFormControlRef = "unable to validate form control ref with information provided"
+)
+
 type FormControlRefList struct {
 	Count              int32             `json:"count"`
 	FormControlRefList []*FormControlRef `json:"formControlList"`
 }
 
 type FormControlRef struct {
-	Id          int32  `json:"id,omitempty"`
-	Ref         string `json:"ref,omitempty"`
-	Name        string `json:"name"`
-	Enabled     bool   `json:"enabled,omitempty"`
-	Description string `json:"description"`
-	FormControl string `json:"formControl"`
-	SortOrder   int32  `json:"order"`
-	Key         string `json:"key"`
-	Value       string `json:"value"`
-	TargetRef   string `json:"targetRef"`
-	Audit       *Audit `json:"audit,omitempty"`
+	Id            int32       `json:"id,omitempty"`
+	TargetRef     string      `json:"targetRef" validate:"required"`
+	SortOrder     int32       `json:"sortOrder" validate:"required"`
+	Description   string      `json:"description" validate:"required"`
+	Name          string      `json:"name" validate:"required"`
+	Key           string      `json:"key" validate:"required"`
+	Value         string      `json:"value" validate:"required"`
+	FormControlId string      `json:"formControlId" validate:"required"`
+	FormControl   FormControl `json:"formControl, omitempty"`
+	Audit         *Audit      `json:"audit,omitempty"`
+	Ref           string      `json:"ref,omitempty"`
+	Version       int32       `json:"version,omitempty"`
 }
 
 func NewFormControlRef() *FormControlRef {
 	return &FormControlRef{
 		Ref: NewRef(FormControlRefTable),
 	}
+}
+
+func (o *FormControlRef) ValidateCreateRequireFields(formControlName string, ref string, value string) error {
+	if formControlName == "" {
+		return errors.New(errNoControlNameProvided)
+	}
+	if ref == "" {
+		return errors.New(errNoRefProvided)
+	}
+	if value == "" {
+		return errors.New(errNoValueProvided)
+	}
+
+	return nil
+}
+
+func (o *FormControlRef) BuildFormControlRefForCreate(formControl FormControl, ref string, value string) error {
+	err := formControl.Validate()
+	if err != nil {
+		return errors.New(fmt.Sprintf(errInvalidFormControl, formControl.Name))
+	}
+	err = json.Unmarshal([]byte(formControl.Control), &formControl.ControlJSON)
+	if err != nil {
+		return errors.New(fmt.Sprintf(errInvalidFormControl, formControl.Name))
+	}
+	o.TargetRef = ref
+	o.SortOrder = 1
+	o.Description = formControl.Description
+	o.Name = formControl.Name
+	o.Key = formControl.ControlJSON.Key
+	o.Value = value
+	o.FormControl = formControl
+	o.FormControlId = formControl.Id
+
+	err = validate.Struct(o)
+	if err != nil {
+		return errors.New(errInvalidFormControlRef)
+	}
+	return nil
 }

--- a/pkg/domain/form_control_ref_test.go
+++ b/pkg/domain/form_control_ref_test.go
@@ -5,8 +5,104 @@ import (
 	"testing"
 )
 
+const (
+	testFormControlName  = "test name"
+	testIssueRef         = "i.abcd.1234"
+	testIssueValue       = "test value"
+	testFormControlRef   = "j.1111.2222"
+	testIssueTargetRef   = "testTargetRef"
+	testFormControlValue = "test value"
+	testFormControlDesc  = "test description"
+)
+
 func TestNewFormControlRef(t *testing.T) {
 	n := NewFormControlRef()
 	assert.NotNil(t, n)
 	assert.Equal(t, FormControlRefTable, n.Ref[0:1])
+}
+
+func TestFormsControlRef_ValidateSuccess(t *testing.T) {
+	var controlRef FormControlRef
+	err := controlRef.ValidateCreateRequireFields(testFormControlName, testIssueRef, testIssueValue)
+
+	assert.Nil(t, err)
+}
+
+func TestFormsControlRef_ValidateError(t *testing.T) {
+	var controlRef FormControlRef
+
+	err := controlRef.ValidateCreateRequireFields(testFormControlName, testIssueRef, "")
+	assert.NotNil(t, err)
+
+	err = controlRef.ValidateCreateRequireFields(testFormControlName, "", testIssueValue)
+	assert.NotNil(t, err)
+
+	err = controlRef.ValidateCreateRequireFields("", testIssueRef, testIssueValue)
+	assert.NotNil(t, err)
+}
+
+func TestFormsControlRef_BuildFormControlRefSuccess(t *testing.T) {
+	var controlRef FormControlRef
+	err := controlRef.BuildFormControlRefForCreate(getValidFormControl(), testIssueRef, testIssueValue)
+
+	assert.Nil(t, err)
+}
+
+func TestFormsControlRef_BuildFormControlRefInvalidForm(t *testing.T) {
+	var controlRef FormControlRef
+	err := controlRef.BuildFormControlRefForCreate(getInvalidFormControl(), testIssueRef, testIssueValue)
+
+	assert.NotNil(t, err)
+}
+
+func TestFormsControlRef_BuildFormControlRefInvalidJSON(t *testing.T) {
+	var controlRef FormControlRef
+	err := controlRef.BuildFormControlRefForCreate(getInvalidFormControlWithBadJSON(), testIssueRef, testIssueValue)
+
+	assert.NotNil(t, err)
+}
+
+func TestFormsControlRef_BuildFormControlRefMissingRef(t *testing.T) {
+	var controlRef FormControlRef
+	err := controlRef.BuildFormControlRefForCreate(getInvalidFormControlWithBadJSON(), "", testIssueValue)
+
+	assert.NotNil(t, err)
+}
+
+func TestFormsControlRef_BuildFormControlRefMissingValue(t *testing.T) {
+	var controlRef FormControlRef
+	err := controlRef.BuildFormControlRefForCreate(getInvalidFormControlWithBadJSON(), testIssueRef, "")
+
+	assert.NotNil(t, err)
+}
+
+func getValidFormControl() FormControl {
+	return FormControl{
+		Id:          "1",
+		Name:        testFormsControlName,
+		Ref:         testFormControlRef,
+		Enabled:     true,
+		Description: testFormControlDesc,
+		Control:     "{\"key\": \"text\",  \"type\": \"text\",  \"templateOptions\": {    \"label\": \"Text\", \"placeholder\": \"Name, email or phone number of Area Manager\", \"required\": true  }}",
+	}
+}
+
+func getInvalidFormControl() FormControl {
+	return FormControl{
+		Ref:         testFormControlRef,
+		Enabled:     true,
+		Description: testFormControlDesc,
+		Control:     "{\"key\": \"text\",  \"type\": \"text\",  \"templateOptions\": {    \"label\": \"Text\", \"placeholder\": \"Name, email or phone number of Area Manager\", \"required\": true  }}",
+	}
+}
+
+func getInvalidFormControlWithBadJSON() FormControl {
+	return FormControl{
+		Id:          "1",
+		Name:        testFormsControlName,
+		Ref:         testFormControlRef,
+		Enabled:     true,
+		Description: testFormControlDesc,
+		Control:     "invalid json",
+	}
 }

--- a/pkg/domain/form_control_ref_test.go
+++ b/pkg/domain/form_control_ref_test.go
@@ -21,21 +21,27 @@ func TestNewFormControlRef(t *testing.T) {
 
 func TestFormsControlRef_ValidateSuccess(t *testing.T) {
 	var controlRef FormControlRef
-	err := controlRef.ValidateCreateRequireFields(testFormControlName, testIssueRef, testIssueValue)
 
+	err := controlRef.ValidateStringParams(testFormControlName, "testError")
+	assert.Nil(t, err)
+
+	err = controlRef.ValidateStringParams(testIssueRef, "testError")
+	assert.Nil(t, err)
+
+	err = controlRef.ValidateStringParams(testIssueValue, "testError")
 	assert.Nil(t, err)
 }
 
 func TestFormsControlRef_ValidateError(t *testing.T) {
 	var controlRef FormControlRef
 
-	err := controlRef.ValidateCreateRequireFields(testFormControlName, testIssueRef, "")
+	err := controlRef.ValidateStringParams(testFormControlName, "testError")
 	assert.NotNil(t, err)
 
-	err = controlRef.ValidateCreateRequireFields(testFormControlName, "", testIssueValue)
+	err = controlRef.ValidateStringParams(testIssueRef, "testError")
 	assert.NotNil(t, err)
 
-	err = controlRef.ValidateCreateRequireFields("", testIssueRef, testIssueValue)
+	err = controlRef.ValidateStringParams(testIssueValue, "testError")
 	assert.NotNil(t, err)
 }
 

--- a/pkg/domain/form_control_ref_test.go
+++ b/pkg/domain/form_control_ref_test.go
@@ -76,7 +76,7 @@ func TestFormsControlRef_BuildFormControlRefMissingValue(t *testing.T) {
 
 func getValidFormControl() FormControl {
 	return FormControl{
-		Id:          "1",
+		Id:          1,
 		Name:        testFormsControlName,
 		Ref:         testFormControlRef,
 		Enabled:     true,
@@ -96,7 +96,7 @@ func getInvalidFormControl() FormControl {
 
 func getInvalidFormControlWithBadJSON() FormControl {
 	return FormControl{
-		Id:          "1",
+		Id:          1,
 		Name:        testFormsControlName,
 		Ref:         testFormControlRef,
 		Enabled:     true,

--- a/pkg/domain/form_control_ref_test.go
+++ b/pkg/domain/form_control_ref_test.go
@@ -6,13 +6,11 @@ import (
 )
 
 const (
-	testFormControlName  = "test name"
-	testIssueRef         = "i.abcd.1234"
-	testIssueValue       = "test value"
-	testFormControlRef   = "j.1111.2222"
-	testIssueTargetRef   = "testTargetRef"
-	testFormControlValue = "test value"
-	testFormControlDesc  = "test description"
+	testFormControlName = "test name"
+	testIssueRef        = "i.abcd.1234"
+	testIssueValue      = "test value"
+	testFormControlRef  = "j.1111.2222"
+	testFormControlDesc = "test description"
 )
 
 func TestNewFormControlRef(t *testing.T) {

--- a/pkg/domain/form_control_ref_test.go
+++ b/pkg/domain/form_control_ref_test.go
@@ -64,14 +64,14 @@ func TestFormsControlRef_BuildFormControlRefInvalidJSON(t *testing.T) {
 
 func TestFormsControlRef_BuildFormControlRefMissingRef(t *testing.T) {
 	var controlRef FormControlRef
-	err := controlRef.BuildFormControlRefForCreate(getInvalidFormControlWithBadJSON(), "", testIssueValue)
+	err := controlRef.BuildFormControlRefForCreate(getValidFormControl(), "", testIssueValue)
 
 	assert.NotNil(t, err)
 }
 
 func TestFormsControlRef_BuildFormControlRefMissingValue(t *testing.T) {
 	var controlRef FormControlRef
-	err := controlRef.BuildFormControlRefForCreate(getInvalidFormControlWithBadJSON(), testIssueRef, "")
+	err := controlRef.BuildFormControlRefForCreate(getValidFormControl(), testIssueRef, "")
 
 	assert.NotNil(t, err)
 }

--- a/pkg/domain/form_control_ref_test.go
+++ b/pkg/domain/form_control_ref_test.go
@@ -35,13 +35,13 @@ func TestFormsControlRef_ValidateSuccess(t *testing.T) {
 func TestFormsControlRef_ValidateError(t *testing.T) {
 	var controlRef FormControlRef
 
-	err := controlRef.ValidateStringParams(testFormControlName, "testError")
+	err := controlRef.ValidateStringParams("", "testError")
 	assert.NotNil(t, err)
 
-	err = controlRef.ValidateStringParams(testIssueRef, "testError")
+	err = controlRef.ValidateStringParams("", "testError")
 	assert.NotNil(t, err)
 
-	err = controlRef.ValidateStringParams(testIssueValue, "testError")
+	err = controlRef.ValidateStringParams("", "testError")
 	assert.NotNil(t, err)
 }
 

--- a/pkg/domain/form_control_test.go
+++ b/pkg/domain/form_control_test.go
@@ -11,7 +11,7 @@ const (
 	testFormsControlString = "Test Control"
 )
 
-func TestFormsControl_ValdiateSuccess(t *testing.T) {
+func TestFormsControl_ValidateSuccess(t *testing.T) {
 	control := FormControl{Ref: testFormsControlRef, Name: testFormsControlName, Control: testFormsControlString}
 
 	err := control.Validate()
@@ -19,7 +19,7 @@ func TestFormsControl_ValdiateSuccess(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestFormsControl_ValdiateError(t *testing.T) {
+func TestFormsControl_ValidateError(t *testing.T) {
 	controlMissingRef := FormControl{Name: testFormsControlName, Control: testFormsControlString}
 	controlMissingName := FormControl{Ref: testFormsControlRef, Control: testFormsControlString}
 	controlMissingControl := FormControl{Ref: testFormsControlRef, Name: testFormsControlName}

--- a/pkg/starkapi/forms_api.go
+++ b/pkg/starkapi/forms_api.go
@@ -102,7 +102,7 @@ func (formsApi *FormsApi) CreateControlOnRef(formControlName string, ref string,
 		return controlRef, err
 	}
 
-	if control.Id == "" || control.Name != formControlName {
+	if control.Id < 1 || control.Name != formControlName {
 		newError := errors.New(fmt.Sprintf(errInvalidControlNameProvided, formControlName))
 		logger.Error(newError)
 		return controlRef, newError

--- a/pkg/starkapi/forms_api.go
+++ b/pkg/starkapi/forms_api.go
@@ -125,7 +125,7 @@ func (formsApi *FormsApi) CreateControlOnRef(formControlName string, ref string,
 
 	err = controlRef.BuildFormControlRefForCreate(control, ref, value)
 	if err != nil {
-		logger.Error(err)
+		logger.Errorf("controlRef.BuildFormControlRefForCreate failed with error : [%s]", err)
 		return controlRef, err
 	}
 
@@ -133,20 +133,20 @@ func (formsApi *FormsApi) CreateControlOnRef(formControlName string, ref string,
 
 	body, err := json.Marshal(controlRef)
 	if err != nil {
-		logger.Error(err)
+		logger.Errorf("failed to unmarshall controlRef json with error : [%s]", err)
 		return controlRef, err
 	}
 
 	resp, err := formsApi.client.post(url, body)
 	if err != nil {
-		logger.Error(err)
+		logger.Errorf("failed to run formsApi.client.post with error : [%s]", err)
 		return controlRef, err
 	}
 
 	if len(resp) > 0 {
 		err = json.Unmarshal(resp, &controlRef)
 		if err != nil {
-			logger.Error(err)
+			logger.Errorf("failed to unmarshall post response json with error : [%s]", err)
 			return controlRef, err
 		}
 	}

--- a/pkg/starkapi/forms_api.go
+++ b/pkg/starkapi/forms_api.go
@@ -95,25 +95,25 @@ func (formsApi *FormsApi) CreateControlOnRef(formControlName string, ref string,
 
 	err := controlRef.ValidateStringParams(formControlName, errNoControlNameProvided)
 	if err != nil {
-		logger.Error(err)
+		logger.Errorf("controlRef.ValidateStringParams failed with error : [%s]", err)
 		return controlRef, err
 	}
 
 	err = controlRef.ValidateStringParams(ref, errNoRefProvided)
 	if err != nil {
-		logger.Error(err)
+		logger.Errorf("controlRef.ValidateStringParams failed with error : [%s]", err)
 		return controlRef, err
 	}
 
 	err = controlRef.ValidateStringParams(value, errNoValueProvided)
 	if err != nil {
-		logger.Error(err)
+		logger.Errorf("controlRef.ValidateStringParams failed with error : [%s]", err)
 		return controlRef, err
 	}
 
 	control, err = formsApi.GetControlByName(formControlName)
 	if err != nil {
-		logger.Error(err)
+		logger.Errorf("formsApi.GetControlByName failed with error : [%s]", err)
 		return controlRef, err
 	}
 

--- a/pkg/starkapi/forms_api.go
+++ b/pkg/starkapi/forms_api.go
@@ -9,6 +9,9 @@ import (
 )
 
 const (
+	errNoControlNameProvided      = "please provide a form control name"
+	errNoRefProvided              = "please provide a ref"
+	errNoValueProvided            = "please provide a value"
 	errInvalidControlNameProvided = "no form control found with name provided : [%s]"
 )
 
@@ -90,7 +93,19 @@ func (formsApi *FormsApi) CreateControlOnRef(formControlName string, ref string,
 	var control domain.FormControl
 	var controlRef domain.FormControlRef
 
-	err := controlRef.ValidateCreateRequireFields(formControlName, ref, value)
+	err := controlRef.ValidateStringParams(formControlName, errNoControlNameProvided)
+	if err != nil {
+		logger.Error(err)
+		return controlRef, err
+	}
+
+	err = controlRef.ValidateStringParams(ref, errNoRefProvided)
+	if err != nil {
+		logger.Error(err)
+		return controlRef, err
+	}
+
+	err = controlRef.ValidateStringParams(value, errNoValueProvided)
 	if err != nil {
 		logger.Error(err)
 		return controlRef, err
@@ -124,12 +139,14 @@ func (formsApi *FormsApi) CreateControlOnRef(formControlName string, ref string,
 
 	resp, err := formsApi.client.post(url, body)
 	if err != nil {
+		logger.Error(err)
 		return controlRef, err
 	}
 
 	if len(resp) > 0 {
 		err = json.Unmarshal(resp, &controlRef)
 		if err != nil {
+			logger.Error(err)
 			return controlRef, err
 		}
 	}

--- a/pkg/starkapi/forms_api_test.go
+++ b/pkg/starkapi/forms_api_test.go
@@ -12,16 +12,18 @@ import (
 )
 
 const (
-	testFormsApiURL        = "/core/forms"
-	testFormsControlPrefix = "/controls"
-	testFormName           = "SampleName"
-	testFormNameInvalid    = "DoesNotExist"
-	errorGetAllControls    = "bad request"
-	testFormsControlName   = "Sample Name"
-	testFormControlRef     = "j.1111.2222"
-	testIssueTargetRef     = "testTargetRef"
-	testFormControlValue   = "test value"
-	testFormControlDesc    = "test description"
+	testFormsApiURL           = "/core/forms"
+	testFormsControlPrefix    = "/controls"
+	testFormName              = "SampleName"
+	testFormNameInvalid       = "DoesNotExist"
+	errorGetAllControls       = "bad request"
+	testFormsControlName      = "Sample Name"
+	testFormControlRef        = "j.1111.2222"
+	testIssueTargetRef        = "testTargetRef"
+	testFormControlValue      = "test value"
+	testFormControlDesc       = "test description"
+	testErrorBadPost          = "bad post error"
+	testErrorGetControlByName = "get control by name error"
 )
 
 func TestFormsApi_host(t *testing.T) {
@@ -283,6 +285,124 @@ func TestFormsApi_CreateControlOnRefBadReturn(t *testing.T) {
 	assert.True(t, errors.As(formsErr, &jsonUnmarshalError))
 }
 
+func TestFormsApi_CreateControlOnRefBadGetControl(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != fmt.Sprintf("%s/%s%s", testFormsApiURL, testIssueTargetRef, testFormsControlPrefix) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	api := Client{}
+	host := server.URL
+
+	api.Init(host)
+
+	formsApi := api.FormsApi
+	formsApi.client = &MockClient{
+		getFunc: func(url string) ([]byte, error) {
+			return nil, errors.New(testErrorGetControlByName)
+		},
+		getHostFunc: func() string {
+			return "someHost"
+		},
+	}
+
+	_, formsErr := formsApi.CreateControlOnRef(testFormsControlName, testIssueTargetRef, testFormControlValue)
+	assert.Equal(t, errors.New(testErrorGetControlByName), formsErr)
+}
+
+func TestFormsApi_CreateControlOnRefBadPost(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != fmt.Sprintf("%s/%s%s", testFormsApiURL, testIssueTargetRef, testFormsControlPrefix) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	api := Client{}
+	host := server.URL
+
+	api.Init(host)
+
+	formsApi := api.FormsApi
+	formsApi.client = &MockClient{
+		getFunc: func(url string) ([]byte, error) {
+			controlList := domain.FormControlList{
+				FormControlList: []*domain.FormControl{
+					{Name: "Name1"},
+					getValidFormControl(),
+					{Name: "Name2"},
+				},
+			}
+			data, _ := json.Marshal(controlList)
+			return data, nil
+		},
+		getHostFunc: func() string {
+			return "someHost"
+		},
+		postFunc: func(url string, body []byte) ([]byte, error) {
+			return nil, errors.New(testErrorBadPost)
+		},
+	}
+
+	_, formsErr := formsApi.CreateControlOnRef(testFormsControlName, testIssueTargetRef, testFormControlValue)
+	assert.Equal(t, errors.New(testErrorBadPost), formsErr)
+}
+
+func TestFormsApi_CreateControlOnRefInvalidFormControlRet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != fmt.Sprintf("%s/%s%s", testFormsApiURL, testIssueTargetRef, testFormsControlPrefix) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	api := Client{}
+	host := server.URL
+
+	api.Init(host)
+
+	formsApi := api.FormsApi
+	formsApi.client = &MockClient{
+		getFunc: func(url string) ([]byte, error) {
+			controlList := domain.FormControlList{
+				FormControlList: []*domain.FormControl{
+					{Name: "Name1"},
+					getInvalidFormControl(),
+					{Name: "Name2"},
+				},
+			}
+			data, _ := json.Marshal(controlList)
+			return data, nil
+		},
+		getHostFunc: func() string {
+			return "someHost"
+		},
+		postFunc: func(url string, body []byte) ([]byte, error) {
+			return []byte("1"), nil
+		},
+	}
+
+	_, formsErr := formsApi.CreateControlOnRef(testFormsControlName, testIssueTargetRef, testFormControlValue)
+	assert.Equal(t, errors.New(fmt.Sprintf(errInvalidControlNameProvided, testFormsControlName)), formsErr)
+}
+
 func TestFormsApi_CreateControlOnRefWithMissingFields(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != fmt.Sprintf("%s/%s%s", testFormsApiURL, testIssueTargetRef, testFormsControlPrefix) {
@@ -316,6 +436,16 @@ func TestFormsApi_CreateControlOnRefWithMissingFields(t *testing.T) {
 func getValidFormControl() *domain.FormControl {
 	return &domain.FormControl{
 		Id:          "1",
+		Name:        testFormsControlName,
+		Ref:         testFormControlRef,
+		Enabled:     true,
+		Description: testFormControlDesc,
+		Control:     "{\"key\": \"text\",  \"type\": \"text\",  \"templateOptions\": {    \"label\": \"Text\", \"placeholder\": \"Name, email or phone number of Area Manager\", \"required\": true  }}",
+	}
+}
+
+func getInvalidFormControl() *domain.FormControl {
+	return &domain.FormControl{
 		Name:        testFormsControlName,
 		Ref:         testFormControlRef,
 		Enabled:     true,

--- a/pkg/starkapi/forms_api_test.go
+++ b/pkg/starkapi/forms_api_test.go
@@ -473,7 +473,7 @@ func TestFormsApi_CreateControlOnRefWithMissingFields(t *testing.T) {
 
 func getValidFormControl() *domain.FormControl {
 	return &domain.FormControl{
-		Id:          "1",
+		Id:          1,
 		Name:        testFormsControlName,
 		Ref:         testFormControlRef,
 		Enabled:     true,
@@ -494,7 +494,7 @@ func getInvalidFormControl() *domain.FormControl {
 
 func getInvalidFormControlWithBadJSON() *domain.FormControl {
 	return &domain.FormControl{
-		Id:          "1",
+		Id:          1,
 		Name:        testFormsControlName,
 		Ref:         testFormControlRef,
 		Enabled:     true,

--- a/pkg/starkapi/forms_api_test.go
+++ b/pkg/starkapi/forms_api_test.go
@@ -438,7 +438,8 @@ func TestFormsApi_CreateControlOnRefBadJSONInControl(t *testing.T) {
 	}
 
 	_, formsErr := formsApi.CreateControlOnRef(testFormsControlName, testIssueTargetRef, testFormControlValue)
-	assert.Equal(t, errors.New(fmt.Sprintf(errInvalidFormControl, testFormsControlName)), formsErr)
+	var jsonSyntaxError *json.SyntaxError
+	assert.True(t, errors.As(formsErr, &jsonSyntaxError))
 }
 
 func TestFormsApi_CreateControlOnRefWithMissingFields(t *testing.T) {

--- a/pkg/starkapi/forms_api_test.go
+++ b/pkg/starkapi/forms_api_test.go
@@ -24,6 +24,7 @@ const (
 	testFormControlDesc       = "test description"
 	testErrorBadPost          = "bad post error"
 	testErrorGetControlByName = "get control by name error"
+	errInvalidFormControl     = "invalid form control provided with name [%s]"
 )
 
 func TestFormsApi_host(t *testing.T) {
@@ -394,13 +395,50 @@ func TestFormsApi_CreateControlOnRefInvalidFormControlRet(t *testing.T) {
 		getHostFunc: func() string {
 			return "someHost"
 		},
-		postFunc: func(url string, body []byte) ([]byte, error) {
-			return []byte("1"), nil
-		},
 	}
 
 	_, formsErr := formsApi.CreateControlOnRef(testFormsControlName, testIssueTargetRef, testFormControlValue)
 	assert.Equal(t, errors.New(fmt.Sprintf(errInvalidControlNameProvided, testFormsControlName)), formsErr)
+}
+
+func TestFormsApi_CreateControlOnRefBadJSONInControl(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != fmt.Sprintf("%s/%s%s", testFormsApiURL, testIssueTargetRef, testFormsControlPrefix) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	api := Client{}
+	host := server.URL
+
+	api.Init(host)
+
+	formsApi := api.FormsApi
+	formsApi.client = &MockClient{
+		getFunc: func(url string) ([]byte, error) {
+			controlList := domain.FormControlList{
+				FormControlList: []*domain.FormControl{
+					{Name: "Name1"},
+					getInvalidFormControlWithBadJSON(),
+					{Name: "Name2"},
+				},
+			}
+			data, _ := json.Marshal(controlList)
+			return data, nil
+		},
+		getHostFunc: func() string {
+			return "someHost"
+		},
+	}
+
+	_, formsErr := formsApi.CreateControlOnRef(testFormsControlName, testIssueTargetRef, testFormControlValue)
+	assert.Equal(t, errors.New(fmt.Sprintf(errInvalidFormControl, testFormsControlName)), formsErr)
 }
 
 func TestFormsApi_CreateControlOnRefWithMissingFields(t *testing.T) {
@@ -451,5 +489,16 @@ func getInvalidFormControl() *domain.FormControl {
 		Enabled:     true,
 		Description: testFormControlDesc,
 		Control:     "{\"key\": \"text\",  \"type\": \"text\",  \"templateOptions\": {    \"label\": \"Text\", \"placeholder\": \"Name, email or phone number of Area Manager\", \"required\": true  }}",
+	}
+}
+
+func getInvalidFormControlWithBadJSON() *domain.FormControl {
+	return &domain.FormControl{
+		Id:          "1",
+		Name:        testFormsControlName,
+		Ref:         testFormControlRef,
+		Enabled:     true,
+		Description: testFormControlDesc,
+		Control:     "invalid json",
 	}
 }


### PR DESCRIPTION

# Updates
- TSP-5553 As a sdk user, I can create a form control on a target ref

### Important Notes
- Updated structs/models. 
- Updated CreateControlOnRef method. 
- Added validation.
- Updated Tests


