### PR TITLE
feature/TSP-5612_VersionType

### DIFF
--- a/pkg/domain/form_control.go
+++ b/pkg/domain/form_control.go
@@ -25,7 +25,7 @@ type FormControl struct {
 			Required    bool   `json:"required"`
 		} `json:"templateOptions,omitempty"`
 	} `json:"-,omitempty"`
-	Version string `json:"version,omitempty"`
+	Version int64  `json:"version,omitempty"`
 	Audit   *Audit `json:"audit,omitempty"`
 	Links   struct {
 		Type string `json:"type"`

--- a/pkg/domain/form_control_ref.go
+++ b/pkg/domain/form_control_ref.go
@@ -28,7 +28,7 @@ type FormControlRef struct {
 	FormControl   FormControl `json:"formControl,omitempty"`
 	Audit         *Audit      `json:"audit,omitempty"`
 	Ref           string      `json:"ref,omitempty"`
-	Version       int32       `json:"version,omitempty"`
+	Version       int64       `json:"version,omitempty"`
 }
 
 func NewFormControlRef() *FormControlRef {

--- a/pkg/domain/form_control_ref_test.go
+++ b/pkg/domain/form_control_ref_test.go
@@ -88,6 +88,7 @@ func getValidFormControl() FormControl {
 		Enabled:     true,
 		Description: testFormControlDesc,
 		Control:     "{\"key\": \"text\",  \"type\": \"text\",  \"templateOptions\": {    \"label\": \"Text\", \"placeholder\": \"Name, email or phone number of Area Manager\", \"required\": true  }}",
+		Version:     1,
 	}
 }
 
@@ -108,5 +109,6 @@ func getInvalidFormControlWithBadJSON() FormControl {
 		Enabled:     true,
 		Description: testFormControlDesc,
 		Control:     "invalid json",
+		Version:     1,
 	}
 }

--- a/pkg/starkapi/forms_api.go
+++ b/pkg/starkapi/forms_api.go
@@ -13,6 +13,7 @@ const (
 	errNoRefProvided              = "please provide a ref"
 	errNoValueProvided            = "please provide a value"
 	errInvalidControlNameProvided = "no form control found with name provided : [%s]"
+	errValidateStringParams       = "controlRef.ValidateStringParams failed with error : [%s]"
 )
 
 type FormsApi struct {
@@ -95,19 +96,19 @@ func (formsApi *FormsApi) CreateControlOnRef(formControlName string, ref string,
 
 	err := controlRef.ValidateStringParams(formControlName, errNoControlNameProvided)
 	if err != nil {
-		logger.Errorf("controlRef.ValidateStringParams failed with error : [%s]", err)
+		logger.Error(fmt.Sprintf(errValidateStringParams, err))
 		return controlRef, err
 	}
 
 	err = controlRef.ValidateStringParams(ref, errNoRefProvided)
 	if err != nil {
-		logger.Errorf("controlRef.ValidateStringParams failed with error : [%s]", err)
+		logger.Error(fmt.Sprintf(errValidateStringParams, err))
 		return controlRef, err
 	}
 
 	err = controlRef.ValidateStringParams(value, errNoValueProvided)
 	if err != nil {
-		logger.Errorf("controlRef.ValidateStringParams failed with error : [%s]", err)
+		logger.Error(fmt.Sprintf(errValidateStringParams, err))
 		return controlRef, err
 	}
 

--- a/pkg/starkapi/forms_api_test.go
+++ b/pkg/starkapi/forms_api_test.go
@@ -24,7 +24,6 @@ const (
 	testFormControlDesc       = "test description"
 	testErrorBadPost          = "bad post error"
 	testErrorGetControlByName = "get control by name error"
-	errInvalidFormControl     = "invalid form control provided with name [%s]"
 )
 
 func TestFormsApi_host(t *testing.T) {


### PR DESCRIPTION
# Updates
- TSP-5612 Change the domain.FormControl version type to int64 from string.

### Important Notes
- Changed version from type string to int64.
- Cleaned lint errors/warnings.
- Removed code smell.

