### PR TITLE
feature/TSP-6448

### DIFF
--- a/pkg/domain/transformer.go
+++ b/pkg/domain/transformer.go
@@ -34,6 +34,25 @@ func parseTransMap(s string) (map[float64]float64, error) {
 	return m, nil
 }
 
+func parseDisplayMap(s string) (map[float64]string, error) {
+	m := make(map[float64]string)
+	for _, kv := range strings.Split(s, ",") {
+		kvSplit := strings.Split(kv, ":")
+		if len(kvSplit) == 2 {
+			key, errKey := strconv.ParseFloat(kvSplit[0], 64)
+			value := kvSplit[1]
+
+			if errKey != nil {
+				logger.Errorf(errKeyMsg, errKey)
+				return nil, errKey
+			}
+
+			m[key] = value
+		}
+	}
+	return m, nil
+}
+
 func Transform(telem *TelemetryMessage, transVal TransformerValue) error {
 	transMap, err := parseTransMap(transVal.ValueType)
 
@@ -48,4 +67,18 @@ func Transform(telem *TelemetryMessage, transVal TransformerValue) error {
 	}
 
 	return nil
+}
+
+func TransformDisplay(telemVal float64, strMap string) (string, error) {
+	displayMap, err := parseDisplayMap(strMap)
+
+	if err != nil {
+		return "", err
+	}
+
+	if val, ok := displayMap[telemVal]; ok {
+		return val, nil
+	}
+
+	return "", nil
 }

--- a/pkg/domain/transformer_test.go
+++ b/pkg/domain/transformer_test.go
@@ -5,6 +5,12 @@ import (
 	"testing"
 )
 
+const (
+	mockVal0       = 0.0
+	mockVal1       = 1.0
+	mockDisplayMap = "0:off,1:on"
+)
+
 func mockTelem() *TelemetryMessage {
 	return &TelemetryMessage{values: map[string]float64{
 		"aRef": 1.00,
@@ -47,4 +53,26 @@ func TestTransform_MisMatchedMapping(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, telem)
 	assert.Equal(t, 328.0, telem.GetValue("aRef"))
+}
+
+func TestTransformDisplay(t *testing.T) {
+	displayVal, err := TransformDisplay(mockVal0, mockDisplayMap)
+	assert.Nil(t, err)
+	assert.Equal(t, "off", displayVal)
+
+	displayVal, err = TransformDisplay(mockVal1, mockDisplayMap)
+	assert.Nil(t, err)
+	assert.Equal(t, "on", displayVal)
+}
+
+func TestTransformDisplay_BadMapping(t *testing.T) {
+	displayVal, err := TransformDisplay(mockVal0, "a string :o")
+	assert.NotNil(t, err)
+	assert.Equal(t, "", displayVal)
+}
+
+func TestTransformDisplay_KeyDoesNotExist(t *testing.T) {
+	displayVal, err := TransformDisplay(3.0, mockDisplayMap)
+	assert.Nil(t, err)
+	assert.Equal(t, "", displayVal)
 }


### PR DESCRIPTION
# Updates
- TSP-6448 Implement display transform logic in go sdk

### Important Notes
- Implemented and tested parseDisplayMap, which takes the string map from a Display Value form ref, and TransformDisplay, which returns the string that a telemetry value maps to, if any

