### PR TITLE
Added handling for brackets in transform/display map

### DIFF
--- a/pkg/domain/transformer.go
+++ b/pkg/domain/transformer.go
@@ -11,8 +11,16 @@ const (
 	errValMsg = "Error converting value to float: %s"
 )
 
+func formatMapString(s string) string {
+	s = strings.Replace(s, " ", "", -1)
+	s = strings.TrimPrefix(s, "[")
+	s = strings.TrimSuffix(s, "]")
+	return s
+}
+
 func parseTransMap(s string) (map[float64]float64, error) {
 	m := make(map[float64]float64)
+	s = formatMapString(s)
 	for _, kv := range strings.Split(s, ",") {
 		kvSplit := strings.Split(kv, ":")
 		if len(kvSplit) == 2 {
@@ -36,6 +44,7 @@ func parseTransMap(s string) (map[float64]float64, error) {
 
 func parseDisplayMap(s string) (map[float64]string, error) {
 	m := make(map[float64]string)
+	s = formatMapString(s)
 	for _, kv := range strings.Split(s, ",") {
 		kvSplit := strings.Split(kv, ":")
 		if len(kvSplit) == 2 {

--- a/pkg/domain/transformer_test.go
+++ b/pkg/domain/transformer_test.go
@@ -6,9 +6,10 @@ import (
 )
 
 const (
-	mockVal0       = 0.0
-	mockVal1       = 1.0
-	mockDisplayMap = "0:off,1:on"
+	mockVal0               = 0.0
+	mockVal1               = 1.0
+	mockDisplayMap         = "0:off,1:on"
+	mockDisplayMapBrackets = "[0:off,1:on]"
 )
 
 func mockTelem() *TelemetryMessage {
@@ -61,6 +62,16 @@ func TestTransformDisplay(t *testing.T) {
 	assert.Equal(t, "off", displayVal)
 
 	displayVal, err = TransformDisplay(mockVal1, mockDisplayMap)
+	assert.Nil(t, err)
+	assert.Equal(t, "on", displayVal)
+}
+
+func TestTransformDisplay_WithBrackets(t *testing.T) {
+	displayVal, err := TransformDisplay(mockVal0, mockDisplayMapBrackets)
+	assert.Nil(t, err)
+	assert.Equal(t, "off", displayVal)
+
+	displayVal, err = TransformDisplay(mockVal1, mockDisplayMapBrackets)
 	assert.Nil(t, err)
 	assert.Equal(t, "on", displayVal)
 }


### PR DESCRIPTION
# Updates
- [ TSP-6448 ] Finish implementing display transform logic in go sdk

### Important Notes
- Both transform value and display value fields are required to be enclosed in brackets
  - go sdk now accounts for opening/closing brackets when parsing the maps
- Code coverage due to old code
