### PR TITLE
feature/TSP-6711_AddPersonParams

### DIFF
--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -93,6 +93,12 @@ type QueryParams struct {
 	Batch         string `json:"batch" schema:"batch" sqlColumn:"batch" sqlType:"text"`
 	SortA         string `json:"sortA" schema:"sortA"`
 	SortD         string `json:"sortD" schema:"sortD"`
+	WebAppMeta    string `json:"webAppMeta" schema:"webAppMeta" sqlColumn:"web_app_meta" sqlType:"text"`
+	FirstName     string `json:"firstName" schema:"firstName" sqlColumn:"first_name" sqlType:"text"`
+	PhoneNumber   string `json:"phoneNumber" schema:"phoneNumber" sqlColumn:"phone_number" sqlType:"text"`
+	Username      string `json:"username" schema:"username" sqlColumn:"username" sqlType:"text"`
+	LastName      string `json:"lastName" schema:"lastName" sqlColumn:"last_name" sqlType:"text"`
+	Email         string `json:"email" schema:"email" sqlColumn:"email" sqlType:"text"`
 }
 
 // HashKey creates a compounded string of the current QueryParams

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -675,3 +675,69 @@ func TestQueryParams_EqNullVal(t *testing.T) {
 
 	assert.Equal(t, "Select * from hello where issue_status_id IS NULL", sql)
 }
+
+func TestQueryParams_WebAppMeta(t *testing.T) {
+	p := QueryParams{WebAppMeta: "some web app meta"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where web_app_meta = $1", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, "some web app meta", args[0])
+}
+
+func TestQueryParams_FirstName(t *testing.T) {
+	p := QueryParams{FirstName: "John"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where first_name = $1", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, "John", args[0])
+}
+
+func TestQueryParams_PhoneNumber(t *testing.T) {
+	p := QueryParams{PhoneNumber: "7161234567"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where phone_number = $1", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, "7161234567", args[0])
+}
+
+func TestQueryParams_Username(t *testing.T) {
+	p := QueryParams{Username: "DoeJ"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where username = $1", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, "DoeJ", args[0])
+}
+
+func TestQueryParams_LastName(t *testing.T) {
+	p := QueryParams{LastName: "Doe"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where last_name = $1", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, "Doe", args[0])
+}
+
+func TestQueryParams_Email(t *testing.T) {
+	p := QueryParams{Email: "test@email.com"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where email = $1", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, "test@email.com", args[0])
+}


### PR DESCRIPTION
# Updates
- [ TSP-6711 ] Add webAppMeta parameter to go-sdk queryable.
- [ TSP-6713 ] Add firstName parameter to go-sdk queryable.
- [ TSP-6717 ] Add phoneNumber parameter to go-sdk queryable.
- [ TSP-6718 ] Add username parameter to go-sdk queryable.
- [ TSP-6720 ] Add lastName parameter to go-sdk queryable.
- [ TSP-6722 ] Add email parameter to go-sdk queryable.

### Important Notes
- Added person params to queryable params list.
- Sonar failing due to uncovered old code

