### PR TITLE
feature/TSP-7249_GetAllPointTypes

### DIFF
--- a/pkg/domain/point_type.go
+++ b/pkg/domain/point_type.go
@@ -1,6 +1,11 @@
 package domain
 
-type PointType struct{
-	Name 			string 		`json:"name,omitempty"`
-	Id 				int32 		`json:"id"`
+type PointType struct {
+	Name string `json:"name,omitempty"`
+	Id   int32  `json:"id"`
+}
+
+type PointTypes struct {
+	Count  int32       `json:"count"`
+	Points []PointType `json:"pointTypeList"`
 }

--- a/pkg/starkapi/point_api.go
+++ b/pkg/starkapi/point_api.go
@@ -8,12 +8,16 @@ import (
 )
 
 type PointApi struct {
-	client *Client
+	client ApiClient
+}
+
+func (pointApi *PointApi) host() string {
+	return pointApi.client.getHost()
 }
 
 func (pointApi *PointApi) delete(id uint32) (*response.DeleteResponse, error) {
 
-	resp, err := pointApi.client.delete(pointUrl(pointApi.client.host, id))
+	resp, err := pointApi.client.delete(pointUrl(pointApi.host(), id))
 
 	if err != nil {
 		return nil, err
@@ -39,11 +43,11 @@ func pointUrl(host string, id uint32) string {
 }
 
 func (pointApi *PointApi) ListPointTypeUrl() string {
-	return fmt.Sprintf("%s/core/lists/pointType", pointApi.client.host)
+	return fmt.Sprintf("%s/core/lists/pointType", pointApi.host())
 }
 
 func (pointApi *PointApi) BaseUrl() string {
-	return fmt.Sprintf("%s/core/points", pointApi.client.host)
+	return fmt.Sprintf("%s/core/points", pointApi.host())
 }
 
 func (pointApi *PointApi) CreateOne(ask domain.Point) (domain.Point, error) {
@@ -218,10 +222,10 @@ func (pointApi *PointApi) HisRead(id uint32, limit uint16, start uint64, end uin
 	return hisRead, nil
 }
 
-func (pointApi *PointApi) GetAllPointTypes() ([]domain.PointTypes, error) {
+func (pointApi *PointApi) GetAllPointTypes() (domain.PointTypes, error) {
 	url := fmt.Sprintf("%s", pointApi.ListPointTypeUrl())
 
-	var pointTypes []domain.PointTypes
+	var pointTypes domain.PointTypes
 
 	resp, err := pointApi.client.get(url)
 	if err != nil {

--- a/pkg/starkapi/point_api.go
+++ b/pkg/starkapi/point_api.go
@@ -38,6 +38,10 @@ func pointUrl(host string, id uint32) string {
 	return fmt.Sprintf("%s/%d", pointsUrl(host), id)
 }
 
+func (pointApi *PointApi) ListPointTypeUrl() string {
+	return fmt.Sprintf("%s/core/lists/pointType", pointApi.client.host)
+}
+
 func (pointApi *PointApi) BaseUrl() string {
 	return fmt.Sprintf("%s/core/points", pointApi.client.host)
 }
@@ -97,7 +101,7 @@ func (pointApi *PointApi) AddNewTag(point domain.Point, name string, value strin
 	return nil
 }
 
-//GetAllTags returns all tags for the provided domain.Point
+// GetAllTags returns all tags for the provided domain.Point
 func (pointApi *PointApi) GetAllTags(point domain.Point) (domain.TagRefs, error) {
 	url := fmt.Sprintf("%s/%v/tags", pointApi.BaseUrl(), point.Id)
 
@@ -115,7 +119,7 @@ func (pointApi *PointApi) GetAllTags(point domain.Point) (domain.TagRefs, error)
 	return tags, nil
 }
 
-//DeleteTag deletes a domain.TagRef from the provided domain.Point
+// DeleteTag deletes a domain.TagRef from the provided domain.Point
 func (pointApi *PointApi) DeleteTag(point domain.Point, tagRef domain.TagRef) error {
 	url := fmt.Sprintf("%s/%v/tags/%v", pointApi.BaseUrl(), point.Id, tagRef.Id)
 
@@ -145,7 +149,7 @@ func (pointApi *PointApi) GetOne(id uint32) (domain.Point, error) {
 	return point, nil
 }
 
-//GetAll returns all points within the given limit and offset
+// GetAll returns all points within the given limit and offset
 func (pointApi *PointApi) GetAll(limit, offset int) (domain.Points, error) {
 	url := fmt.Sprintf("%s?limit=%v?offset=%v", pointApi.BaseUrl(), limit, offset)
 	var points domain.Points
@@ -212,4 +216,24 @@ func (pointApi *PointApi) HisRead(id uint32, limit uint16, start uint64, end uin
 	}
 
 	return hisRead, nil
+}
+
+func (pointApi *PointApi) GetAllPointTypes() ([]domain.PointTypes, error) {
+	url := fmt.Sprintf("%s", pointApi.ListPointTypeUrl())
+
+	var pointTypes []domain.PointTypes
+
+	resp, err := pointApi.client.get(url)
+	if err != nil {
+		return pointTypes, err
+	}
+
+	if len(resp) > 0 {
+		err = json.Unmarshal(resp, &pointTypes)
+		if err != nil {
+			return pointTypes, err
+		}
+	}
+
+	return pointTypes, nil
 }

--- a/pkg/starkapi/point_api_test.go
+++ b/pkg/starkapi/point_api_test.go
@@ -1,13 +1,20 @@
 package starkapi
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
+const (
+	testGetPointTypesApiURL = "/core/lists/pointType"
+)
+
 func TestPointsUrl(t *testing.T) {
-	host := "http://example.com"
-	expectedURL := "http://example.com/core/points"
+	host := "https://example.com"
+	expectedURL := "https://example.com/core/points"
 
 	result := pointsUrl(host)
 
@@ -15,11 +22,43 @@ func TestPointsUrl(t *testing.T) {
 }
 
 func TestPointUrl(t *testing.T) {
-	host := "http://example.com"
+	host := "https://example.com"
 	id := uint32(123)
-	expectedURL := "http://example.com/core/points/123"
+	expectedURL := "https://example.com/core/points/123"
 
 	result := pointUrl(host, id)
 
 	assert.Equal(t, expectedURL, result, "Generated URL does not match the expected URL")
+}
+
+func TestGetAllPointTypes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != fmt.Sprintf("%s", testGetPointTypesApiURL) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	api := Client{}
+	host := server.URL
+
+	api.Init(host)
+
+	pointApi := api.PointApi
+
+	_, pointErr := pointApi.GetAllPointTypes()
+	assert.Equal(t, nil, pointErr)
+
+	badApi := Client{}
+	badApi.Init("/bad")
+
+	badPointApi := badApi.PointApi
+	_, badFormsApiErr := badPointApi.GetAllPointTypes()
+	assert.NotEqual(t, nil, badFormsApiErr)
 }

--- a/pkg/starkapi/point_api_test.go
+++ b/pkg/starkapi/point_api_test.go
@@ -1,7 +1,9 @@
 package starkapi
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/Stark-Tech-Group/stg-sdk-golang/pkg/domain"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +12,12 @@ import (
 
 const (
 	testGetPointTypesApiURL = "/core/lists/pointType"
+	testPointTypeName1      = "Name1"
+	testPointTypeId1        = int32(1)
+	testPointTypeName2      = "Name2"
+	testPointTypeId2        = int32(2)
+	testPointTypeName3      = "Name3"
+	testPointTypeId3        = int32(3)
 )
 
 func TestPointsUrl(t *testing.T) {
@@ -61,4 +69,54 @@ func TestGetAllPointTypes(t *testing.T) {
 	badPointApi := badApi.PointApi
 	_, badFormsApiErr := badPointApi.GetAllPointTypes()
 	assert.NotEqual(t, nil, badFormsApiErr)
+}
+
+func TestGetAllPointTypesWithResp(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != fmt.Sprintf("%s", testGetPointTypesApiURL) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	api := Client{}
+	host := server.URL
+
+	api.Init(host)
+
+	pointApi := api.PointApi
+	pointApi.client = &MockClient{
+		getFunc: func(url string) ([]byte, error) {
+			pointTypeList := domain.PointTypes{
+				Points: []domain.PointType{
+					{Name: "Name1", Id: 1},
+					{Name: "Name2", Id: 2},
+					{Name: "Name3", Id: 3},
+				},
+			}
+			data, _ := json.Marshal(pointTypeList)
+			return data, nil
+		},
+		getHostFunc: func() string {
+			return "someHost"
+		},
+		postFunc: func(url string, body []byte) ([]byte, error) {
+			return nil, nil
+		},
+	}
+
+	res, pointTypesErr := pointApi.GetAllPointTypes()
+	assert.Equal(t, nil, pointTypesErr)
+	assert.Equal(t, testPointTypeName1, res.Points[0].Name)
+	assert.Equal(t, testPointTypeId1, res.Points[0].Id)
+	assert.Equal(t, testPointTypeName2, res.Points[1].Name)
+	assert.Equal(t, testPointTypeId2, res.Points[1].Id)
+	assert.Equal(t, testPointTypeName3, res.Points[2].Name)
+	assert.Equal(t, testPointTypeId3, res.Points[2].Id)
+
 }


### PR DESCRIPTION
# Updates
- [ TSP-7249 ] As a go sdk user I can get all point types

**Sonar failing due to old code.

### Important Notes
- Added new ListPointTypeUrl.
- Added new method to get the list of all point types.
- Added tests for new method.
- Changed test http to https to remove warning.
- Updated tests and pointClient to use APIClient with host() method to be able to use MockClient.


