### PR TITLE
added `lastAuth` to query params, tested

### DIFF
--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -110,6 +110,7 @@ type QueryParams struct {
 	Deleted             string `json:"deleted" schema:"deleted" sqlColumn:"deleted" sqlType:"boolean"`
 	AccountExpired      string `json:"accountExpired" schema:"accountExpired" sqlColumn:"account_expired" sqlType:"boolean"`
 	AccountLocked       string `json:"accountLocked" schema:"accountLocked" sqlColumn:"account_locked" sqlType:"boolean"`
+	LastAuth            string `json:"lastAuth" scheme:"lastAuth" sqlColumn:"last_auth" sqlType:"bigint"`
 }
 
 // HashKey creates a compounded string of the current QueryParams

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -957,3 +957,14 @@ func TestQueryParams_BetweenWithInt32(t *testing.T) {
 	assert.Equal(t, "Select * from hello where name = $1 and gsf BETWEEN $2 AND $3", sql)
 	assert.Equal(t, 3, len(args))
 }
+
+func TestQueryParams_LastAuth(t *testing.T) {
+	p := QueryParams{LastAuth: "1234567890"}
+
+	sql, args, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where last_auth = $1", sql)
+	assert.Equal(t, 1, len(args))
+	assert.Equal(t, int64(1234567890), args[0])
+}


### PR DESCRIPTION
# Updates
- [TSP-7593] Error when trying to sort last login data on user table

### Important Notes
- added `lastAuth`  to query params
- added testing for `lastAuth` query param


[TSP-7593]: https://controlfreak.atlassian.net/browse/TSP-7593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ