### PR TITLE
changed 'scheme' in QueryParams.LastAuth field to 'schema'

### DIFF
--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -110,7 +110,7 @@ type QueryParams struct {
 	Deleted             string `json:"deleted" schema:"deleted" sqlColumn:"deleted" sqlType:"boolean"`
 	AccountExpired      string `json:"accountExpired" schema:"accountExpired" sqlColumn:"account_expired" sqlType:"boolean"`
 	AccountLocked       string `json:"accountLocked" schema:"accountLocked" sqlColumn:"account_locked" sqlType:"boolean"`
-	LastAuth            string `json:"lastAuth" scheme:"lastAuth" sqlColumn:"last_auth" sqlType:"bigint"`
+	LastAuth            string `json:"lastAuth" schema:"lastAuth" sqlColumn:"last_auth" sqlType:"bigint"`
 }
 
 // HashKey creates a compounded string of the current QueryParams

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -968,3 +968,12 @@ func TestQueryParams_LastAuth(t *testing.T) {
 	assert.Equal(t, 1, len(args))
 	assert.Equal(t, int64(1234567890), args[0])
 }
+
+func TestQueryParmas_SortByLastAuth(t *testing.T) {
+	p := QueryParams{SortA: "lastAuth"}
+
+	sql, _, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello order by last_auth asc", sql)
+}


### PR DESCRIPTION
# Updates
- TSP-7618 Change "scheme" in QueryParams.LastAuth field to "schema"

### Important Notes
- Changed "scheme" in QueryParams.LastAuth field to "schema" to allow for sorting by last auth
