### PR TITLE
feature/OP-1215

### DIFF
--- a/pkg/starkapi/query-params.go
+++ b/pkg/starkapi/query-params.go
@@ -112,10 +112,14 @@ type QueryParams struct {
 	LastAuth             string `json:"lastAuth" schema:"lastAuth" sqlColumn:"last_auth" sqlType:"bigint"`
 	AssetType            string `json:"assetType" schema:"assetType" sqlColumn:"asset_type" sqlType:"text"`
 	NotificationStatusId string `json:"notificationStatusId" schema:"notificationStatusId" sqlColumn:"notification_status_id" sqlType:"bigint"`
-	Verified string `json:"verified" schema:"verified" sqlColumn:"verified" sqlType:"boolean"`
+	Verified             string `json:"verified" schema:"verified" sqlColumn:"verified" sqlType:"boolean"`
+	ProfileCount         string `json:"profileCount" schema:"profileCount" sqlColumn:"profile_count" sqlType:"bigint"`
+	SiteCount            string `json:"siteCount" schema:"siteCount" sqlColumn:"site_count" sqlType:"bigint"`
+	EquipCount           string `json:"equipCount" schema:"equipCount" sqlColumn:"equip_count" sqlType:"bigint"`
+	PointCount           string `json:"pointCount" schema:"pointCount" sqlColumn:"point_count" sqlType:"bigint"`
 
-	SortA                string `json:"sortA" schema:"sortA"`
-	SortD                string `json:"sortD" schema:"sortD"`
+	SortA string `json:"sortA" schema:"sortA"`
+	SortD string `json:"sortD" schema:"sortD"`
 }
 
 // HashKey creates a compounded string of the current QueryParams

--- a/pkg/starkapi/query-params_test.go
+++ b/pkg/starkapi/query-params_test.go
@@ -1074,3 +1074,51 @@ func TestQueryParams_SortByNotificationStatusId(t *testing.T) {
 
 	assert.Equal(t, "Select * from hello order by notification_status_id asc", sql)
 }
+
+func TestQueryParams_SortByProfileCount(t *testing.T) {
+	p := QueryParams{
+		Verified: "true",
+		SortA:    "profileCount",
+	}
+
+	sql, _, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where verified = $1 order by profile_count asc", sql)
+}
+
+func TestQueryParams_SortBySiteCount(t *testing.T) {
+	p := QueryParams{
+		Verified: "true",
+		SortA:    "siteCount",
+	}
+
+	sql, _, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where verified = $1 order by site_count asc", sql)
+}
+
+func TestQueryParams_SortByEquipCount(t *testing.T) {
+	p := QueryParams{
+		Verified: "true",
+		SortA:    "equipCount",
+	}
+
+	sql, _, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where verified = $1 order by equip_count asc", sql)
+}
+
+func TestQueryParams_SortByPointCount(t *testing.T) {
+	p := QueryParams{
+		Verified: "true",
+		SortA:    "pointCount",
+	}
+
+	sql, _, err := p.BuildParameterizedQuery("Select * from hello")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "Select * from hello where verified = $1 order by point_count asc", sql)
+}


### PR DESCRIPTION
# Updates
- jira:OP-1215 Add profile_count, site_count, equip_count, and point_count as fields that can be sorted/filtered on to the QueryParams in Go SDK

### Important Notes
- Added ProfileCount, SiteCount, EquipCount, and PointCount as fields to the QueryParams struct

