### PR TITLE
OP-3012: Update SonarQube scan action to v6

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -19,7 +19,7 @@ jobs:
       - name: test
         run: go test ./... -coverprofile ./coverage/coverage.out -json > ./coverage/results.json
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

Updates the SonarSource/sonarqube-scan-action from v5 to v6 in the GitHub Actions workflow. This addresses dependabot PR #146.

## Changes

- Updated `.github/workflows/sonar.yml` to use `SonarSource/sonarqube-scan-action@v6`

## Breaking Change Note

v6 has a breaking change regarding `args` parsing (migrated from Bash to JS). However, this workflow does **not** use any `args` parameter, so the upgrade is safe and requires no additional changes.

## Type

- [x] Feature (GitHub Actions update)
- [x] Dependency update

## Test Plan

- Verify SonarCloud scan runs successfully on this PR
- The workflow should execute without errors

---

jira:OP-3012