### PR TITLE
OP-3509: scope GitHub Actions workflow permissions (CodeQL)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   dev-build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -18,6 +18,8 @@ on:
 
 jobs:
   create-release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,9 +5,13 @@ on:
     branches:
       - dev
 
+permissions: read-all
+
 jobs:
   dev-build:
     if: ${{ github.event_name == 'push' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_build.yml
     with:
       projectName: stg-sdk-golang
@@ -15,6 +19,8 @@ jobs:
   dev-release:
     needs: [ "dev-build" ]
     if: ${{ github.event_name == 'push' }}
+    permissions:
+      contents: write
     uses: ./.github/workflows/_release.yml
     with:
       major: 1

--- a/.github/workflows/feature_bug.yml
+++ b/.github/workflows/feature_bug.yml
@@ -6,9 +6,13 @@ on:
       - "bug/**"
       - "bugfix/**"
 
+permissions: read-all
+
 jobs:
   feature-bug-build:
     if: ${{ github.event_name == 'push' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_build.yml
     with:
       projectName: stg-sdk-golang

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -6,6 +6,9 @@ on:
       - "feature/**"
       - "bug/**"
       - "bugfix/**"
+
+permissions: read-all
+
 jobs:
   sonarcloud:
     name: SonarCloud

--- a/plans/OP-3509.md
+++ b/plans/OP-3509.md
@@ -1,0 +1,142 @@
+# OP-3509: Code-quality sweep: stg-sdk-golang
+
+## Ticket Context
+
+- **Type:** Task
+- **Priority:** Not specified
+- **Jira:** https://controlfreak.atlassian.net/browse/OP-3509
+- **Status:** In Progress
+- **Assignee:** Chris Michels
+
+### Description
+
+Code-quality sweep — `stg-sdk-golang`. Cluster archetype with **reusable-workflow nuance**: 5 workflow files (vs the standard 3) including 2 reusable workflows (`_build.yml`, `_release.yml`). All 6 findings are `actions/missing-workflow-permissions`. Recipe in `code-quality/docs/PATTERNS.md` applies, with the **reusable-workflow constraint** subsection (added in the OP-3474 audit pass).
+
+### Findings (6 medium CodeQL alerts)
+
+| File | Alerts | Type |
+|------|-------:|------|
+| `.github/workflows/dev.yml` | 2 (lines 10, 16) | caller |
+| `.github/workflows/feature_bug.yml` | 1 (line 11) | caller |
+| `.github/workflows/sonar.yml` | 1 (line 11) | standalone |
+| `.github/workflows/_build.yml` | 1 (line 13) | reusable |
+| `.github/workflows/_release.yml` | 1 (line 21) | reusable |
+
+### Acceptance Criteria
+
+- All 5 workflow files have explicit `permissions:` (top-level on standalones/callers, job-level on reusables)
+- Reusable workflows (`_build.yml`, `_release.yml`) declare permissions **only at the job level** — top-level on a `workflow_call` reusable triggers GitHub `startup_failure` (PATTERNS.md "Reusable-workflow constraint")
+- Callers (`dev.yml`, `feature_bug.yml`) declare top-level `read-all` + per-job `permissions:` on every `uses:` block — back-flow from reusable to caller does not happen
+- Per-job overrides applied where any job pushes/tags/comments
+- CodeQL re-scan: 6 → 0
+- Build/test green on feature branch
+- Feature branch GPG-signed, base `dev`
+
+### Related Context
+
+- Cluster ticket — OP-3497..OP-3508 are sibling sweeps for other repos sharing the same recipe
+- Reference plan: `code-quality/plans/projects/stg-sdk-golang.md` (in code-quality repo, not local)
+- Recipe: `code-quality/docs/PATTERNS.md` — "Missing top-level workflow permissions block" + reusable-workflow subsection
+- Sibling shipped reference: `stark-asset-api` (OP-3467) — `read-all` floor + per-job `contents: write` on `dev-release` only; sonar gets `read-all` floor with **no per-job override**
+- Out of scope: OP-3420 (SonarCloud CI failure on Go 1.25) — different surface area
+
+## Codebase Analysis
+
+### Affected Modules
+
+Only `.github/workflows/*.yml` — no Go code changes.
+
+### Key Files
+
+| File | Current State | Required Change |
+|------|---------------|-----------------|
+| `.github/workflows/_build.yml` | No `permissions:` block; reusable; checkout + go test/build + upload-artifact | **Job-level** `permissions: contents: read` on `dev-build` job. NO top-level. |
+| `.github/workflows/_release.yml` | No `permissions:` block; reusable; download-artifact + `softprops/action-gh-release` | **Job-level** `permissions: contents: write` on `create-release` job. NO top-level. |
+| `.github/workflows/dev.yml` | No `permissions:` block; calls `_build.yml` + `_release.yml` | Top-level `permissions: read-all` + per-job `contents: read` on `dev-build`, `contents: write` on `dev-release`. |
+| `.github/workflows/feature_bug.yml` | No `permissions:` block; calls `_build.yml` | Top-level `permissions: read-all` + per-job `contents: read` on `feature-bug-build`. |
+| `.github/workflows/sonar.yml` | No `permissions:` block; uses `GITHUB_TOKEN` for PR-info correlation (read) | Top-level `permissions: read-all`. **No per-job override** — matches sibling convention; SonarCloud PR decoration uses GitHub App, not workflow token. |
+
+### Existing Patterns
+
+The workflows are minimal and use shared-template style:
+- Reusable workflows prefixed with `_` (`_build.yml`, `_release.yml`)
+- `workflow_call` triggers with typed inputs (`projectName`, `major`, `minor`, `contentType`)
+- Pinned action versions (`@v4`, `@v5`, `@v2`, `@v6`) — already secure-by-default
+- No existing `permissions:` blocks anywhere — this is the gap CodeQL is flagging
+
+### Test Coverage
+
+No CI tests for workflow files themselves. Verification path:
+- `actionlint` for syntax validation
+- `go build ./... && go test ./... && go vet ./...` to prove no Go file was touched
+- Push branch → observe `feature_bug.yml` runs `_build.yml` successfully (proves reusable workflow plumbing still works with the new permissions)
+- `sonar.yml` runs on the same push → proves Sonar PR-info correlation still works on read-only
+- Release pipeline (`dev.yml` → `_release.yml`) only fires on push to `dev`. **Cannot pre-test pre-merge.** Name in PR description; have fast-follow PR ready.
+
+## Implementation Plan
+
+### Phase 1: Reusable workflows — job-level permissions ONLY
+
+> **PATTERNS.md "Reusable-workflow constraint":** putting top-level `permissions:` on a `workflow_call` reusable when callers also declare per-job permissions causes GitHub runtime `startup_failure`. `actionlint` does not catch this. Always declare reusables at job-level only.
+
+- [ ] Add **job-level** `permissions: contents: read` to `_build.yml` `dev-build` job
+  - Rationale: only checks out code, runs Go tooling, uploads artifacts (artifacts upload uses runtime API, no repo write)
+- [ ] Add **job-level** `permissions: contents: write` to `_release.yml` `create-release` job
+  - Rationale: `softprops/action-gh-release@v2` creates GitHub releases + pushes tags
+
+### Phase 2: Caller workflows — top-level + per-job on every `uses:` block
+
+> Per PATTERNS.md, the caller's `uses:` job must declare its own `permissions:` block — back-flow from the reusable does not happen. Strict per-job blocks (including read-only) match the documented pattern.
+
+- [ ] `dev.yml`:
+  - Top-level: `permissions: read-all`
+  - `dev-build` job: per-job `contents: read`
+  - `dev-release` job: per-job `contents: write`
+- [ ] `feature_bug.yml`:
+  - Top-level: `permissions: read-all`
+  - `feature-bug-build` job: per-job `contents: read`
+
+### Phase 3: Standalone workflow
+
+- [ ] `sonar.yml`:
+  - Top-level: `permissions: read-all`
+  - **No per-job override.** SonarCloud's PR decoration uses its installed GitHub App, not the workflow's `GITHUB_TOKEN`. The token only correlates analysis with the PR (read).
+  - Matches `stark-asset-api` shipped convention.
+
+### Phase 4: Verification & branch hygiene
+
+- [ ] `actionlint` clean (already clean at baseline)
+- [ ] `go build ./... && go test ./... && go vet ./...` clean (sanity — workflow changes don't touch Go)
+- [ ] `golangci-lint run ./...` shows no new issues vs baseline (baseline: 41 pre-existing, out of scope)
+- [ ] Push branch — observe:
+  - `feature_bug.yml` triggers `_build.yml` successfully (validates caller↔reusable contract)
+  - `sonar.yml` runs and posts results
+  - No release runs (release only fires on push to `dev`)
+- [ ] CodeQL re-scan: confirm 6 → 0
+- [ ] Confirm commits GPG-signed (`git log --show-signature`)
+- [ ] Confirm branch base is `dev`
+
+## Resolved Decisions
+
+1. **Reusable workflows — top-level vs job-level permissions**: **Job-level only.** PATTERNS.md "Reusable-workflow constraint" documents the `startup_failure` risk; not worth speculating that `.yml` extension might behave differently from `.yaml`.
+2. **Sonar per-job permissions**: **None.** Top-level `read-all` is sufficient. Matches sibling shipped convention (`stark-asset-api`). The SonarCloud GitHub App handles PR decoration; workflow token is read-only.
+3. **Caller per-job blocks on read-only `uses:` jobs**: **Strict pattern.** Every caller `uses:` job gets an explicit `permissions:` block — including read-only `dev-build` and `feature-bug-build`. Avoids relying on inheritance behavior the doc explicitly says doesn't back-flow.
+
+## Open Questions
+
+1. **`actions: read` for `download-artifact@v4` in `_release.yml`**: v4 reads from the Actions runtime API. Default `GITHUB_TOKEN` carries this without explicit grant. **Wait for CodeQL re-scan**: if the alert clears, no action; if a new alert appears, fast-follow PR adds `actions: read`.
+
+## Guardrails
+
+- **GPG signing required** — all commits must be signed (per user CLAUDE.md). Never use `--no-gpg-sign`.
+- **Base branch is `dev`** — not `main`. PR target also `dev`.
+- **Branch naming** — `feature/OP-3509_*` format already in place.
+- **Plan doc lives in commit** — per memory `feedback_plan_doc_in_commit.md`, this `plans/OP-3509.md` ships in the ticket commit (not local-only).
+- **YAML indent — 2 spaces** — match existing workflow files exactly.
+- **No drive-by changes** — only `permissions:` blocks. Don't bump action versions, don't reorder steps, don't touch the 41 pre-existing golangci-lint issues.
+
+## PR description must call out
+
+- **Post-merge-only verification path**: `dev.yml` → `_release.yml` chain cannot be exercised on this feature branch. Watcher should confirm first post-merge `dev` push completes its release job.
+- **Fast-follow ready**: if `download-artifact@v4` needs `actions: read`, follow-up PR will add it to `_release.yml` `create-release` job.
+- **No client-observable behavior change** for SDK consumers — workflow permission scoping is internal CI hygiene.


### PR DESCRIPTION
## Summary

**sonar issue is pre-existing**

Adds explicit `permissions:` blocks to all 5 GitHub Actions workflows to clear 6 medium-severity `actions/missing-workflow-permissions` CodeQL findings. Without explicit scoping, `GITHUB_TOKEN` inherits the repo default scope — broader than least-privilege.

This repo carries the **reusable-workflow constraint** documented in `code-quality/docs/PATTERNS.md`: top-level `permissions:` on a `workflow_call` reusable causes GitHub `startup_failure` when callers also declare per-job perms on the `uses:` block. Reusables here (`_build.yml`, `_release.yml`) therefore declare permissions only at the job level; callers (`dev.yml`, `feature_bug.yml`) declare top-level `read-all` plus per-job permissions on every `uses:` block (back-flow from reusable to caller does not happen).

`sonar.yml` gets top-level `read-all` only — matches sibling shipped convention (`stark-asset-api`, OP-3467). SonarCloud's PR decoration uses its installed GitHub App, not the workflow `GITHUB_TOKEN`; the token only correlates analysis with the PR (read).

## Changes

- `.github/workflows/_build.yml` — job-level `contents: read` on `dev-build`
- `.github/workflows/_release.yml` — job-level `contents: write` on `create-release` (creates releases + pushes tags via `softprops/action-gh-release@v2`)
- `.github/workflows/dev.yml` — top-level `read-all`; per-job `contents: read` on `dev-build`, `contents: write` on `dev-release`
- `.github/workflows/feature_bug.yml` — top-level `read-all`; per-job `contents: read` on `feature-bug-build`
- `.github/workflows/sonar.yml` — top-level `read-all` only (no per-job override)
- `plans/OP-3509.md` — implementation plan, shipped in-commit per repo convention

No Go code changes. No `go.mod` / `go.sum` changes. **No SDK consumer behavior change** — workflow permission scoping is internal CI hygiene.

## Verification

| Check | Baseline | Final |
|---|---|---|
| `actionlint` | exit 0 | exit 0 |
| `go build ./...` | exit 0 | exit 0 |
| `go vet ./...` | exit 0 | exit 0 |
| `go test ./...` | all pass | all pass |
| `golangci-lint run` | 41 issues | 41 issues (zero new; pre-existing, out of scope) |
| GPG signatures | n/a | 5/5 signed |

Expected CodeQL re-scan: 6 → 0 alerts cleared (2 from reusables + 2 from `dev.yml` + 1 from `feature_bug.yml` + 1 from `sonar.yml`).

## Type

- [x] Enhancement (CI security hardening)
- [ ] Bug fix
- [ ] Dependency update

## Test Plan

- [ ] On push: `feature_bug.yml` triggers `_build.yml` cleanly — proves caller↔reusable permission contract on the only path we *can* exercise pre-merge
- [ ] On push: `sonar.yml` runs and posts SonarCloud results normally
- [ ] CodeQL re-scan confirms 6 → 0
- [ ] **Post-merge-only path**: `dev.yml` → `_release.yml` chain only fires on push to `dev`. Cannot pre-merge-test. Watch the first post-merge `dev` push to confirm the release job completes and creates the GitHub release. If it `startup_failure`s, fast-follow PR is ready.
- [ ] **Fast-follow contingency**: if a new CodeQL alert appears on `_release.yml` for `actions: read` (`download-artifact@v4` reads from the Actions runtime API), a follow-up PR will add it to the `create-release` job permissions.

## Pattern reference

Recipe: `code-quality/docs/PATTERNS.md` — "Missing top-level workflow permissions block" + "Reusable-workflow constraint" subsection (originally surfaced in OP-3474 / `stark-k8-manifest`).

---

jira:OP-3509